### PR TITLE
Conflict handler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ You can provide the `handle_conflict` function, which would be called if two rec
 the same key when clustering (just be aware, this function would not protect you against
 overwrites by the same node).
 
+Without `handle_conflict`, conflicting records would overwrite each other when joining.
+When joining nodes we insert all data from one node to another and vice versa without any extra check.
+Check `join_works_with_existing_data_with_conflicts` test case as an example.
+
 # API
 
 The main module is cets.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ should be inside an ETS key for this to work (or a pid).
 When some node is down, we remove all records that are owned by this node.
 When a node reappears, the records are added back.
 
+You can also use totally random keys. In this case all keys should be unique.
+We also support tables with type=bag. In such case all records would remain in the table.
+
+You can provide the `handle_conflict` function, which would be called if two records have
+the same key when clustering (just be aware, this function would not protect you against
+overwrites by the same node).
+
 # API
 
 The main module is cets.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -129,7 +129,9 @@
 -type handle_down_fun() :: fun((#{remote_pid := pid(), table := table_name()}) -> ok).
 -type handle_conflict_fun() :: fun((tuple(), tuple()) -> tuple()).
 -type start_opts() :: #{
-    handle_down => handle_down_fun(), type => ordered_set | bag, keypos => non_neg_integer(),
+    type => ordered_set | bag,
+    keypos => non_neg_integer(),
+    handle_down => handle_down_fun(),
     handle_conflict => handle_conflict_fun()
 }.
 
@@ -517,8 +519,14 @@ handle_unpause2(Mon, Mons, State) ->
     {reply, ok, State3}.
 
 -spec handle_get_info(state()) -> {reply, info(), state()}.
-handle_get_info(State = #{tab := Tab, other_servers := Servers,
-                          mon_pid := MonPid, opts := Opts}) ->
+handle_get_info(
+    State = #{
+        tab := Tab,
+        other_servers := Servers,
+        mon_pid := MonPid,
+        opts := Opts
+    }
+) ->
     Info = #{
         table => Tab,
         nodes => lists:usort(pids_to_nodes([self() | Servers])),

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -151,7 +151,7 @@
 %%   Called when two records have the same key when clustering.
 %%   NewRecord would be the record CETS would keep in the table under the key.
 %%   Does not work for bags.
-%%   We recomment to define that function if keys could have conflicts.
+%%   We recommend to define that function if keys could have conflicts.
 %%   This function would be called once for each conflicting key.
 %%   We recommend to keep that function pure (or at least no blocking calls from it).
 -spec start(table_name(), start_opts()) -> {ok, pid()}.
@@ -555,10 +555,7 @@ call_user_handle_down(RemotePid, _State = #{tab := Tab, opts := Opts}) ->
 
 -type start_error() :: bag_with_conflict_handler.
 -spec check_opts(start_opts()) -> [start_error()].
-check_opts(Opts) ->
-    check_bag_with_conflict_handler(Opts).
-
-check_bag_with_conflict_handler(#{handle_conflict := _, type := bag}) ->
+check_opts(#{handle_conflict := _, type := bag}) ->
     [bag_with_conflict_handler];
-check_bag_with_conflict_handler(_) ->
+check_opts(_) ->
     [].

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -101,24 +101,31 @@ apply_resolver(ordered_set, LocalDump, RemoteDump, F, Pos) ->
     %% Both dumps are sorted by the key (the lowest key first)
     apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, [], []).
 
-apply_resolver_for_sorted([X|LocalDump], [X|RemoteDump], F, Pos, LocalAcc, RemoteAcc) ->
+apply_resolver_for_sorted([X | LocalDump], [X | RemoteDump], F, Pos, LocalAcc, RemoteAcc) ->
     %% Presents in both dumps, skip it at all (we don't need to insert it, it is already inserted)
     apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, LocalAcc, RemoteAcc);
-apply_resolver_for_sorted([L|LocalDump] = LocalDumpFull,
-                          [R|RemoteDump] = RemoteDumpFull,
-                          F, Pos, LocalAcc, RemoteAcc) ->
+apply_resolver_for_sorted(
+    [L | LocalDump] = LocalDumpFull,
+    [R | RemoteDump] = RemoteDumpFull,
+    F,
+    Pos,
+    LocalAcc,
+    RemoteAcc
+) ->
     LKey = element(Pos, L),
     RKey = element(Pos, R),
     if
         LKey =:= RKey ->
             New = F(L, R),
-            apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, [New|LocalAcc], [New|RemoteAcc]);
+            apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, [New | LocalAcc], [
+                New | RemoteAcc
+            ]);
         LKey < RKey ->
             %% Record exist only in the local dump
-            apply_resolver_for_sorted(LocalDump, RemoteDumpFull, F, Pos, [L|LocalAcc], RemoteAcc);
+            apply_resolver_for_sorted(LocalDump, RemoteDumpFull, F, Pos, [L | LocalAcc], RemoteAcc);
         true ->
             %% Record exist only in the remote dump
-            apply_resolver_for_sorted(LocalDumpFull, RemoteDump, F, Pos, LocalAcc, [R|RemoteAcc])
+            apply_resolver_for_sorted(LocalDumpFull, RemoteDump, F, Pos, LocalAcc, [R | RemoteAcc])
     end;
 apply_resolver_for_sorted(LocalDump, RemoteDump, _F, _Pos, LocalAcc, RemoteAcc) ->
     {lists:reverse(LocalAcc, LocalDump), lists:reverse(RemoteAcc, RemoteDump)}.

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -121,10 +121,10 @@ apply_resolver_for_sorted(
                 New | RemoteAcc
             ]);
         LKey < RKey ->
-            %% Record exist only in the local dump
+            %% Record exists only in the local dump
             apply_resolver_for_sorted(LocalDump, RemoteDumpFull, F, Pos, [L | LocalAcc], RemoteAcc);
         true ->
-            %% Record exist only in the remote dump
+            %% Record exists only in the remote dump
             apply_resolver_for_sorted(LocalDumpFull, RemoteDump, F, Pos, LocalAcc, [R | RemoteAcc])
     end;
 apply_resolver_for_sorted(LocalDump, RemoteDump, _F, _Pos, LocalAcc, RemoteAcc) ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -93,7 +93,7 @@ maybe_apply_resolver(LocalDump, RemoteDump, Opts = #{handle_conflict := F}) ->
     Type = maps:get(type, Opts, ordered_set),
     Pos = maps:get(keypos, Opts, 1),
     apply_resolver(Type, LocalDump, RemoteDump, F, Pos);
-maybe_apply_resolver(LocalDump, RemoteDump, Opts) ->
+maybe_apply_resolver(LocalDump, RemoteDump, _Opts) ->
     {LocalDump, RemoteDump}.
 
 %% Bags do not have conflicts, so do not define a resolver for them.
@@ -120,5 +120,5 @@ apply_resolver_for_sorted([L|LocalDump] = LocalDumpFull,
             %% Record exist only in the remote dump
             apply_resolver_for_sorted(LocalDumpFull, RemoteDump, F, Pos, LocalAcc, [R|RemoteAcc])
     end;
-apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, LocalAcc, RemoteAcc) ->
+apply_resolver_for_sorted(LocalDump, RemoteDump, _F, _Pos, LocalAcc, RemoteAcc) ->
     {lists:reverse(LocalAcc, LocalDump), lists:reverse(RemoteAcc, RemoteDump)}.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -166,8 +166,9 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_ke
     [#user{age = 25}] = ets:lookup(T2, alice).
 
 %% Keep record with highest timestamp
-resolve_user_conflict(U1 = #user{updated = TS1}, _U2 = #user{updated = TS2})
-    when TS1 > TS2 ->
+resolve_user_conflict(U1 = #user{updated = TS1}, _U2 = #user{updated = TS2}) when
+    TS1 > TS2
+->
     U1;
 resolve_user_conflict(_U1, U2) ->
     U2.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -16,6 +16,7 @@ all() ->
         join_works_with_existing_data_with_conflicts,
         join_works_with_existing_data_with_conflicts_and_defined_conflict_handler,
         join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_more_keys,
+        bag_with_conflict_handler_not_allowed,
         join_with_the_same_pid,
         test_multinode,
         node_list_is_correct,
@@ -149,6 +150,10 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_mo
 
 resolve_highest({K, A}, {K, B}) ->
     {K, max(A, B)}.
+
+bag_with_conflict_handler_not_allowed(_Config) ->
+    {error, [bag_with_conflict_handler]} =
+        cets:start(ex1tab, #{handle_conflict => fun resolve_highest/2, type => bag}).
 
 join_with_the_same_pid(_Config) ->
     {ok, Pid} = cets:start(joinsame, #{}),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -16,6 +16,7 @@ all() ->
         join_works_with_existing_data_with_conflicts,
         join_works_with_existing_data_with_conflicts_and_defined_conflict_handler,
         join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_more_keys,
+        join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_keypos2,
         bag_with_conflict_handler_not_allowed,
         join_with_the_same_pid,
         test_multinode,
@@ -37,7 +38,8 @@ all() ->
         delete_request_from_bag,
         delete_request_many_from_bag,
         insert_into_bag_is_replicated,
-        insert_into_keypos_table
+        insert_into_keypos_table,
+        info_contains_opts
     ].
 
 init_per_suite(Config) ->
@@ -147,6 +149,28 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_mo
     Dump = cets:dump(T1),
     Dump = cets:dump(T2),
     Dump = cets:dump(T3).
+
+-record(user, {name, age, updated}).
+
+%% Test with records (which require keypos = 2 option)
+join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_keypos2(_Config) ->
+    Opts = #{handle_conflict => fun resolve_user_conflict/2, keypos => 2},
+    {ok, Pid1} = cets:start(T1 = keypos2_tab1, Opts),
+    {ok, Pid2} = cets:start(T2 = keypos2_tab2, Opts),
+    cets:insert(T1, #user{name = alice, age = 30, updated = erlang:system_time()}),
+    cets:insert(T2, #user{name = alice, age = 25, updated = erlang:system_time()}),
+    %% Join will copy and merge existing tables
+    ok = cets_join:join(keypos2_lock, #{}, Pid1, Pid2),
+    %% Last inserted record is in the table
+    [#user{age = 25}] = ets:lookup(T1, alice),
+    [#user{age = 25}] = ets:lookup(T2, alice).
+
+%% Keep record with highest timestamp
+resolve_user_conflict(U1 = #user{updated = TS1}, _U2 = #user{updated = TS2})
+    when TS1 > TS2 ->
+    U1;
+resolve_user_conflict(_U1, U2) ->
+    U2.
 
 resolve_highest({K, A}, {K, B}) ->
     {K, max(A, B)}.
@@ -419,6 +443,10 @@ insert_into_keypos_table(_Config) ->
     cets:insert(T, {rec, 2}),
     [{rec, 1}] = lists:sort(ets:lookup(T, 1)),
     [{rec, 1}, {rec, 2}] = lists:sort(cets:dump(T)).
+
+info_contains_opts(_Config) ->
+    {ok, Pid} = cets:start(info_contains_opts, #{type => bag}),
+    #{opts := #{type := bag}} = cets:info(Pid).
 
 start(Node, Tab) ->
     rpc(Node, cets, start, [Tab, #{}]).


### PR DESCRIPTION
As a developer I want to use non-random and non-node-specific keys. This means duplicates are possible when two nodes are joined together.

Changes:
- Add an option `handle_conflict` to define a function which could be used to choose between two records if there is a conflict on the cluster join.
- Tests.
