### PR TITLE
Use aliases for communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 _build/
 # vim temporary files
-*.sw*
+.*.sw*
+.*.sv*
+rebar3.crashdump
+codecov.json

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,9 @@
 {profiles, [
     {test, [
         {plugins, [
-            {rebar3_codecov, "0.4.0"}
-        ]}
+            {rebar3_codecov, "0.5.0"}
+        ]},
+        %% Include test suites into the cover report
+        {src_dirs, ["src", "test"]}
     ]}
 ]}.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -510,7 +510,7 @@ ets_delete_objects(Tab, Objects) ->
 
 reply_updated(Alias, ReplyTo, #{server_mask := Mask}) ->
     %% nosuspend makes message sending unreliable
-    erlang:send(ReplyTo, {cets_updated, Alias, Mask}, [noconnect]).
+    erlang:send(ReplyTo, {ack, Alias, Mask}, [noconnect]).
 
 send_to_remote(RemoteAlias, Msg) ->
     erlang:send(RemoteAlias, Msg, [noconnect]).

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -31,7 +31,7 @@
     table_name/1,
     other_nodes/1,
     other_pids/1,
-    make_alias_for/2,
+    make_aliases_for/2,
     pause/1,
     unpause/2,
     sync/1,
@@ -151,7 +151,7 @@
     | table_name
     | get_info
     | other_pids
-    | {make_alias_for, [pid()]}
+    | {make_aliases_for, [pid()]}
     | {unpause, reference()}
     | send_dump_msg()
     | {apply_dump, DumpRef :: reference()}.
@@ -290,9 +290,9 @@ wait_response(Mon, Timeout) ->
         Other -> error(Other)
     end.
 
--spec make_alias_for(server_ref(), [server_ref()]) -> [{server_ref(), reference()}].
-make_alias_for(Server, RemotePids) ->
-    cets_call:long_call(Server, {make_alias_for, RemotePids}).
+-spec make_aliases_for(server_ref(), [server_ref()]) -> [{server_ref(), reference()}].
+make_aliases_for(Server, RemotePids) ->
+    cets_call:long_call(Server, {make_aliases_for, RemotePids}).
 
 %% Get a list of other nodes in the cluster that are connected together.
 -spec other_nodes(server_ref()) -> [node()].
@@ -374,7 +374,7 @@ handle_call(
     {noreply, State#{backlog := [{Alias, Msg} | Backlog]}};
 handle_call(other_pids, _From, State = #{just_pids := Pids}) ->
     {reply, Pids, State};
-handle_call({make_alias_for, Pids}, _From, State) ->
+handle_call({make_aliases_for, Pids}, _From, State) ->
     %% Create channels used to deliver remote_op messages
     Aliases = [{Pid, erlang:monitor(process, Pid, [{alias, demonitor}])} || Pid <- Pids],
     {reply, Aliases, State};

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -345,7 +345,9 @@ init({Tab, Opts}) ->
 handle_call({op, Msg}, {_, [alias | Alias]}, State = #{pause_monitors := []}) ->
     handle_op(Alias, Msg, State),
     {noreply, State};
-handle_call({op, Msg}, {_, [alias | Alias]}, State = #{pause_monitors := [_ | _], backlog := Backlog}) ->
+handle_call(
+    {op, Msg}, {_, [alias | Alias]}, State = #{pause_monitors := [_ | _], backlog := Backlog}
+) ->
     %% Backlog is a list of pending operation, when our server is paused.
     %% The list would be applied, once our server is unpaused.
     {noreply, State#{backlog := [{Alias, Msg} | Backlog]}};

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -119,7 +119,7 @@
     | sync
     | table_name
     | get_info
-    | other_servers
+    | other_pids
     | {make_alias_for, [pid()]}
     | {unpause, reference()}
     | {send_dump, Num :: server_num(), NewServers :: [server_tuple()], Dump :: [tuple()]}.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -535,13 +535,13 @@ handle_op(From = {_Mon, Pid}, Msg, State) when is_pid(Pid) ->
 %   Pid ! {cets_reply, Mon, WaitInfo},
     ok.
 
-replicate({Alias, _} = From, Msg, #{just_dests := []}) ->
-    Alias ! {cets_ok, Alias};
-replicate({Alias, _} = From, Msg, #{mon_pid := MonPid, just_dests := Dests, remote_bits := Bits}) ->
-    MonPid ! {From, Bits},
+replicate({Alias, _} = From, Msg, #{mon_pid := MonPid, just_dests := [_|_] = Dests, remote_bits := Bits}) ->
+    MonPid ! {Alias, Bits},
     %% Reply would be routed directly to FromPid
     [send_to_remote(Dest, {remote_op, Dest, Alias, MonPid, Msg}) || Dest <- Dests],
-    ok.
+    ok;
+replicate({Alias, _} = From, Msg, #{just_dests := []}) ->
+    Alias ! {cets_ok, Alias}.
 %   {Bits, MonPid}.
 
 apply_backlog(State = #{backlog := Backlog}) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -459,7 +459,7 @@ has_remote_pid(RemotePid, Servers) ->
 
 reply_updated({Mon, Pid}) ->
     %% nosuspend makes message sending unreliable
-    erlang:send(Pid, {updated, Mon, self()}, [noconnect]).
+    erlang:send(Mon, {cets_updated, Mon, self()}, [noconnect]).
 
 send_to_remote(RemotePid, Msg) ->
     erlang:send(RemotePid, Msg, [noconnect]).

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -525,8 +525,7 @@ ets_delete_objects(Tab, Objects) ->
     ok.
 
 reply_updated(Alias, ReplyTo, #{server_mask := Mask}) ->
-    %% nosuspend makes message sending unreliable
-    erlang:send(ReplyTo, {ack, Alias, Mask}, [noconnect]).
+    cets_ack:ack(ReplyTo, Alias, Mask).
 
 send_to_remote(RemoteAlias, Msg) ->
     erlang:send(RemoteAlias, Msg, [noconnect]).

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -289,7 +289,7 @@ init({Tab, Opts}) ->
     KeyPos = maps:get(keypos, Opts, 1),
     %% Match result to prevent the Dialyzer warning
     _ = ets:new(Tab, [Type, named_table, public, {keypos, KeyPos}]),
-    _ = ets:new(MonTab, [public, named_table]),
+    _ = ets:new(MonTab, [public, named_table, {write_concurrency, true}]),
     {ok, MonPid} = cets_mon_cleaner:start_link(MonTab, MonTab),
     {ok, #{
         tab => Tab,

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -266,7 +266,10 @@ delete_objects_request(Server, Objects) ->
 
 -spec wait_response(request_id(), non_neg_integer() | infinity) -> ok.
 wait_response(Mon, Timeout) ->
-    gen_server:wait_response(Mon, Timeout).
+    case gen_server:wait_response(Mon, Timeout) of
+        {reply, ok} -> ok;
+        Other -> error(Other)
+    end.
 
 -spec make_alias_for(server_ref(), [server_ref()]) -> [{server_ref(), reference()}].
 make_alias_for(Server, RemotePids) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -283,6 +283,15 @@ info(Server) ->
 
 -spec init({table_name(), start_opts()}) -> {ok, state()}.
 init({Tab, Opts}) ->
+    %% While this process could produce a lot of messages,
+    %% blocking it would not help on the real system
+    %% (probably any blocking of this process would make CPU/memory usage higher)
+    %% Blocking this process could reduce a bit of pressure on the overloaded dist
+    %% connection, but we would have to send the data there anyway.
+    %% Instead of being blocked we could process remote_op messages and reduce our
+    %% message queue.
+    %% It is supported starting from OTP 25.3.
+    catch process_flag(async_dist, true),
     process_flag(message_queue_data, off_heap),
     MonTab = list_to_atom(atom_to_list(Tab) ++ "_mon"),
     Type = maps:get(type, Opts, ordered_set),

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -569,7 +569,7 @@ handle_op(Alias, Msg, State) ->
 
 replicate(Alias, _Msg, #{remote_bits := 0}) ->
     %% Skip replication
-    cets_call:reply(Alias, ok);
+    cets_call:reply(Alias);
 replicate(Alias, Msg, #{ack_pid := AckPid, just_dests := Dests, remote_bits := Bits}) ->
     cets_ack:add(AckPid, Alias, Bits),
     [send_to_remote(Dest, {remote_op, Dest, Alias, AckPid, Msg}) || Dest <- Dests],

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -297,7 +297,7 @@ init({Tab, Opts}) ->
     Type = maps:get(type, Opts, ordered_set),
     KeyPos = maps:get(keypos, Opts, 1),
     %% Match result to prevent the Dialyzer warning
-    _ = ets:new(Tab, [Type, named_table, public, {keypos, KeyPos}]),
+    _ = ets:new(Tab, [Type, named_table, public, {keypos, KeyPos}, {read_concurrency, true}]),
     _ = ets:new(MonTab, [public, named_table, {write_concurrency, true}]),
     {ok, MonPid} = cets_mon_cleaner:start_link(MonTab, MonTab),
     {ok, #{

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -179,7 +179,16 @@
     handle_conflict => handle_conflict_fun()
 }.
 
--export_type([request_id/0, op/0, server_ref/0, long_msg/0, info/0, table_name/0, called_from/0]).
+-export_type([
+    request_id/0,
+    op/0,
+    server_ref/0,
+    long_msg/0,
+    info/0,
+    table_name/0,
+    called_from/0,
+    server_tuple/0
+]).
 
 %% API functions
 

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -575,6 +575,7 @@ replicate(From, _Msg, #{remote_bits := 0}) ->
 replicate(From, Msg, #{ack_pid := AckPid, just_dests := Dests, remote_bits := Bits}) ->
     cets_ack:add(AckPid, From, Bits),
     [send_to_remote(Dest, {remote_op, Dest, From, AckPid, Msg}) || Dest <- Dests],
+    %% AckPid would call cets_call:reply(From) ones all the remote servers reply
     ok.
 
 apply_backlog(State = #{backlog := Backlog}) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -642,6 +642,7 @@ handle_get_info(
         just_dests := Dests,
         ack_pid := AckPid,
         pending_aliases := PendingAliases,
+        pause_monitors := PauseRefs,
         opts := Opts
     }
 ) ->
@@ -653,6 +654,7 @@ handle_get_info(
         memory => ets:info(Tab, memory),
         ack_pid => AckPid,
         pending_aliases => PendingAliases,
+        pause_monitors => PauseRefs,
         opts => Opts
     },
     {reply, Info, State}.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -325,7 +325,7 @@ init({Tab, Opts}) ->
     %% Match result to prevent the Dialyzer warning
     _ = ets:new(Tab, [Type, named_table, public, {keypos, KeyPos}, {read_concurrency, true}]),
     MonName = list_to_atom(atom_to_list(Tab) ++ "_mon"),
-    {ok, MonPid} = cets_mon_cleaner:start_link(MonName),
+    {ok, MonPid} = cets_ack:start_link(MonName),
     {ok, #{
         tab => Tab,
         mon_pid => MonPid,

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -101,20 +101,41 @@
 -type server_tuple() :: {pid(), Monitor :: reference(), Dest :: reference()}.
 -type server_nums() :: map().
 -type state() :: #{
+    %% ETS table to write data into
     tab := table_name(),
+    %% Process, that would receive acks from the remote nodes
     ack_pid := pid(),
+    %% Each node in cluster has an unique integer id.
+    %% Assigned in cets_join when joining the cluster.
+    %% Could be reassigned during another join.
     server_num := server_num(),
+    %% Mask to remove our server_num from a bitmask.
+    %% Used in cets_bits when collecting acks.
     server_mask := server_mask(),
+    %% Map to get server_num of other servers in the cluster.
+    %% Assigned during the cluster join.
     server_nums := server_nums(),
+    %% A list of remote servers.
+    %% Each server has a pid, a monitor and an alias to send messages.
+    %% Assigned during the cluster join.
     other_servers := [server_tuple()],
+    %% Bitfield with ones set for the remote server_nums.
     remote_bits := non_neg_integer(),
+    %% Pids from other_servers list.
     just_pids := [pid()],
+    %% Aliases from other_servers list.
     just_dests := [reference()],
     opts := start_opts(),
+    %% Pending operations collected when we are paused.
     backlog := [backlog_entry()],
+    %% Who are blocking us from writing into the table.
     pause_monitors := [pause_monitor()],
     %% Optional
+    %% We store dump between send_dump and apply_dump calls.
     pending_dump := send_dump_msg() | none(),
+    %% Reference assigned when joining.
+    %% All nodes in the cluster should have the same last_applied_dump_ref.
+    %% Verified in handle_check_server function.
     last_applied_dump_ref := reference()
 }.
 

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -449,11 +449,11 @@ has_remote_pid(RemotePid, Servers) ->
     lists:member(RemotePid, Servers).
 
 reply_updated({Mon, Pid}) ->
-    %% We really don't wanna block this process
-    erlang:send(Pid, {updated, Mon, self()}, [noconnect, nosuspend]).
+    %% nosuspend makes message sending unreliable
+    erlang:send(Pid, {updated, Mon, self()}, [noconnect]).
 
 send_to_remote(RemotePid, Msg) ->
-    erlang:send(RemotePid, Msg, [noconnect, nosuspend]).
+    erlang:send(RemotePid, Msg, [noconnect]).
 
 %% Handle operation from a remote node
 handle_remote_op(From, Msg, State) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -62,6 +62,8 @@
     delete_many/2,
     delete_object/2,
     delete_objects/2,
+    dump/1,
+    remote_dump/1,
     pause/1,
     unpause/2,
     sync/1,
@@ -484,7 +486,7 @@ set_servers(Servers, State) ->
 %% Make a bitmask with bits set to 1 for still alive remote servers
 make_remote_bits(Pids, #{server_nums := Nums}) ->
     RemoteNums = [Num || {Pid, Num} <- maps:to_list(Nums), lists:member(Pid, Pids)],
-    lists:foldl(fun cets_bits:set_flag/2, 0, RemoteNums).
+    cets_bits:set_flags(RemoteNums, 0).
 
 handle_down(Mon, Pid, Reason, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -411,7 +411,7 @@ notify_remote_down(RemotePid, MonTab) ->
     notify_remote_down_loop(RemotePid, List).
 
 notify_remote_down_loop(RemotePid, [{Mon, Pid} | List]) ->
-    Pid ! {remote_down, Mon, RemotePid},
+    Mon ! {cets_remote_down, Mon, RemotePid},
     notify_remote_down_loop(RemotePid, List);
 notify_remote_down_loop(_RemotePid, []) ->
     ok.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -231,9 +231,9 @@ table_name(Server) ->
     cets_call:long_call(Server, table_name).
 
 -spec send_dump(server_ref(), reference(), server_nums(), [server_tuple()], [tuple()]) -> ok.
-send_dump(Server, Ref, Nums, NewServers, OurDump) ->
+send_dump(Server, DumpRef, Nums, NewServers, OurDump) ->
     Info = #{msg => send_dump, count => length(OurDump)},
-    cets_call:long_call(Server, {send_dump, Ref, Nums, NewServers, OurDump}, Info).
+    cets_call:long_call(Server, {send_dump, DumpRef, Nums, NewServers, OurDump}, Info).
 
 -spec apply_dump(server_ref(), reference()) -> ok.
 apply_dump(Server, Ref) ->
@@ -446,10 +446,10 @@ handle_send_dump(M, State) ->
     {reply, ok, State#{pending_dump => M}}.
 
 handle_apply_dump(
-    Ref,
+    DumpRef,
     State = #{
         tab := Tab,
-        pending_dump := {send_dump, Ref, Nums, NewServers, Dump},
+        pending_dump := {send_dump, DumpRef, Nums, NewServers, Dump},
         ack_pid := AckPid
     }
 ) ->
@@ -459,7 +459,7 @@ handle_apply_dump(
         server_num := Num,
         server_mask := cets_bits:unset_flag_mask(Num),
         server_nums := Nums,
-        last_applied_dump_ref := Ref
+        last_applied_dump_ref := DumpRef
     }),
     %% We need to clean cets_ack process to avoid possible infinite
     %% gen_server:wait_response/2 calls from the client.

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -7,6 +7,7 @@
 -export([
     start_link/1,
     add/3,
+    ack/3,
     send_remote_down/2,
     erase/1
 ]).
@@ -32,6 +33,15 @@ start_link(Name) ->
 -spec add(pid(), reference(), integer()) -> ok.
 add(AckPid, Alias, Bits) ->
     AckPid ! {add, Alias, Bits},
+    ok.
+
+%% Called by a remote server after an operation is applied.
+%% Alias is an alias from the original gen_server:call made by a client.
+%% Mask identifies the remote server.
+-spec ack(pid(), reference(), integer()) -> ok.
+ack(AckPid, Alias, Mask) ->
+    %% nosuspend makes message sending unreliable
+    erlang:send(AckPid, {ack, Alias, Mask}, [noconnect]),
     ok.
 
 -spec send_remote_down(pid(), non_neg_integer()) -> ok.

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -1,9 +1,6 @@
-%% Monitor Table contains processes, that are waiting for writes to finish.
-%% It is usually cleaned automatically.
-%% Unless the caller process crashes.
-%% This server removes such entries from the MonTab.
-%% We don't expect the MonTab to be extremely big, so this check should be quick.
--module(cets_mon_cleaner).
+%% Contains processes, that are waiting for writes to finish.
+%% Collects acks from nodes in the cluster.
+-module(cets_ack).
 -behaviour(gen_server).
 
 -export([start_link/1]).

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -68,7 +68,14 @@ send_down_all(_Key, _Val) ->
     true.
 
 handle_remote_down(Mask, State) ->
-    maps:fold(fun(K, V, Acc) when is_reference(K) -> handle_updated(K, Mask, Acc, V); (_, _, Acc) -> Acc end, State, State).
+    maps:fold(
+        fun
+            (K, V, Acc) when is_reference(K) -> handle_updated(K, Mask, Acc, V);
+            (_, _, Acc) -> Acc
+        end,
+        State,
+        State
+    ).
 
 handle_updated(Mon, Mask, State) ->
     handle_updated(Mon, Mask, State, maps:get(Mon, State, false)).

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -81,7 +81,7 @@ handle_updated(Mon, Mask, State) ->
     handle_updated(Mon, Mask, State, maps:get(Mon, State, false)).
 
 handle_updated(Mon, Mask, State, Bits) when is_integer(Bits) ->
-    case apply_mask(Mask, Bits) of
+    case cets_bits:apply_mask(Mask, Bits) of
         0 ->
             cets_call:reply(Mon, ok),
             maps:remove(Mon, State);
@@ -90,6 +90,3 @@ handle_updated(Mon, Mask, State, Bits) when is_integer(Bits) ->
     end;
 handle_updated(_Mon, _Mask, State, false) ->
     {noreply, State}.
-
-apply_mask(Mask, Bits) ->
-    Bits band Mask.

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -92,18 +92,13 @@ handle_erase(State) ->
     #{}.
 
 send_down_all(Mon, _Val) when is_reference(Mon) ->
-    cets_call:reply(Mon, ok);
-send_down_all(_Key, _Val) ->
-    ok.
+    cets_call:reply(Mon, ok).
 
 -spec handle_remote_down(integer(), state()) -> state().
 handle_remote_down(Num, State) ->
     Mask = cets_bits:unset_flag_mask(Num),
     maps:fold(
-        fun
-            (K, V, Acc) when is_reference(K) -> handle_updated(K, Mask, Acc, V);
-            (_, _, Acc) -> Acc
-        end,
+        fun(K, V, Acc) when is_reference(K) -> handle_updated(K, Mask, Acc, V) end,
         State,
         State
     ).

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -40,7 +40,7 @@ handle_cast(Msg, State) ->
     ?LOG_ERROR(#{what => unexpected_cast, msg => Msg}),
     {noreply, State}.
 
-handle_info({cets_updated, Mon, Mask}, State) ->
+handle_info({ack, Mon, Mask}, State) ->
     {noreply, handle_updated(Mon, Mask, State)};
 handle_info({Mon, Bits}, State) when is_reference(Mon) ->
     {noreply, maps:put(Mon, Bits, State)};

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -92,7 +92,7 @@ handle_erase(State) ->
     #{}.
 
 send_down_all(Mon, _Val) when is_reference(Mon) ->
-    cets_call:reply(Mon, ok).
+    cets_call:reply(Mon).
 
 -spec handle_remote_down(integer(), state()) -> state().
 handle_remote_down(Num, State) ->
@@ -107,7 +107,7 @@ handle_updated(Mon, Mask, State) ->
 handle_updated(Mon, Mask, State, Bits) when is_integer(Bits) ->
     case cets_bits:apply_mask(Mask, Bits) of
         0 ->
-            cets_call:reply(Mon, ok),
+            cets_call:reply(Mon),
             maps:remove(Mon, State);
         Bits2 ->
             State#{Mon := Bits2}

--- a/src/cets_bits.erl
+++ b/src/cets_bits.erl
@@ -1,0 +1,17 @@
+%% Functions for bit operations
+-module(cets_bits).
+-export([set_flag/2]).
+-export([unset_flag_mask/1]).
+-export([apply_mask/2]).
+
+-spec set_flag(Pos :: non_neg_integer(), Bits :: integer()) -> Bits :: integer().
+set_flag(Pos, Bits) ->
+    Bits bor (1 bsl Pos).
+
+-spec unset_flag_mask(Pos :: non_neg_integer()) -> Mask :: integer().
+unset_flag_mask(Pos) ->
+    bnot (1 bsl Pos).
+
+-spec apply_mask(Mask :: integer(), Bits :: integer()) -> Bits :: integer().
+apply_mask(Mask, Bits) ->
+    Bits band Mask.

--- a/src/cets_bits.erl
+++ b/src/cets_bits.erl
@@ -1,12 +1,15 @@
 %% Functions for bit operations
 -module(cets_bits).
--export([set_flag/2]).
+-export([set_flags/2]).
 -export([unset_flag_mask/1]).
 -export([apply_mask/2]).
 
 -spec set_flag(Pos :: non_neg_integer(), Bits :: integer()) -> Bits :: integer().
 set_flag(Pos, Bits) ->
     Bits bor (1 bsl Pos).
+
+set_flags(Positions, Bits) ->
+    lists:foldl(fun set_flag/2, Bits, Positions).
 
 -spec unset_flag_mask(Pos :: non_neg_integer()) -> Mask :: integer().
 unset_flag_mask(Pos) ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -38,11 +38,6 @@ long_call(Server, Msg, Info) ->
 %% Contacts the local server to broadcast multinode operation.
 %% Returns immediately.
 %% You can wait for response from all nodes by calling wait_response/2.
-%% You would have to call wait_response/2 to process incoming messages and to remove the monitor
-%% (or the caller process can just exit to clean this up).
-%%
-%% (could not be implemented by an async gen_server:call, because we want
-%% to keep monitoring the local gen_server till all responses are received).
 -spec async_operation(server_ref(), op()) -> request_id().
 async_operation(Server, Msg) ->
     gen_server:send_request(Server, {op, Msg}).

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -79,13 +79,13 @@ wait_response(Mon, Timeout) ->
 
 %% Wait for response from the remote nodes that the operation is completed.
 %% remote_down is sent by the local server, if the remote server is down.
-wait_for_updated(Mon, {Servers, MonTab}, Timeout) ->
+wait_for_updated(Mon, {Servers, MonPid}, Timeout) ->
     try
         do_wait_for_updated(Mon, Servers, Timeout)
     after
         erlang:demonitor(Mon, [flush]),
-        flush_messages(Mon),
-        MonTab ! Mon
+        MonPid ! Mon,
+        flush_messages(Mon)
     end.
 
 do_wait_for_updated(_Mon, 0, _Timeout) ->
@@ -105,7 +105,7 @@ do_wait_for_updated(Mon, Servers, Timeout) ->
             %% Local server is down, this is a critical error
             error({cets_down, Reason})
     after Timeout ->
-                error(timeout)
+        error(timeout)
     end.
 
 unset_flag(all, _Bits) ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -85,7 +85,7 @@ wait_for_updated(Mon, {Servers, MonTab}, Timeout) ->
     after
         erlang:demonitor(Mon, [flush]),
         flush_messages(Mon),
-        ets:delete(MonTab, Mon)
+        MonTab ! Mon
     end.
 
 do_wait_for_updated(_Mon, 0, _Timeout) ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -94,7 +94,7 @@ do_wait_for_updated(Mon, Servers, Timeout) ->
             %% A replication confirmation from the remote server is received
             Servers2 = lists:delete(Pid, Servers),
             do_wait_for_updated(Mon, Servers2, Timeout);
-        {remote_down, Mon, Pid} ->
+        {cets_remote_down, Mon, Pid} ->
             %% This message is sent by our local server when
             %% the remote server is down condition is detected
             Servers2 = lists:delete(Pid, Servers),

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -61,7 +61,7 @@ async_operation(Server, Msg) ->
 sync_operation(Server, Msg) ->
     Mon = async_operation(Server, Msg),
     %% We monitor the local server until the response from all servers is collected.
-%   wait_response(Mon, infinity).
+    %   wait_response(Mon, infinity).
     wait_response(Mon, 5000).
 
 %% This function must be called to receive the result of the multinode operation.
@@ -104,12 +104,12 @@ do_wait_for_updated(Mon, Servers, Timeout) ->
             %% Local server is down, this is a critical error
             error({cets_down, Reason})
     after Timeout ->
-%       error(timeout)
+        %       error(timeout)
         error({timeout, Servers})
     end.
 
 unset_flag(Pos, Bits) ->
-   Bits band (bnot (1 bsl Pos)).
+    Bits band (bnot (1 bsl Pos)).
 
 -spec where(server_ref()) -> pid() | undefined.
 where(Pid) when is_pid(Pid) -> Pid;

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -61,8 +61,7 @@ async_operation(Server, Msg) ->
 sync_operation(Server, Msg) ->
     Mon = async_operation(Server, Msg),
     %% We monitor the local server until the response from all servers is collected.
-    %   wait_response(Mon, infinity).
-    wait_response(Mon, 5000).
+    wait_response(Mon, infinity).
 
 %% This function must be called to receive the result of the multinode operation.
 -spec wait_response(request_id(), non_neg_integer() | infinity) -> ok.

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -47,7 +47,7 @@ long_call(Server, Msg, Info) ->
 async_operation(Server, Msg) ->
     case where(Server) of
         Pid when is_pid(Pid) ->
-            Mon = erlang:monitor(process, Pid),
+            Mon = erlang:monitor(process, Pid, [{alias, demonitor}]),
             gen_server:cast(Server, {op, {Mon, self()}, Msg}),
             Mon;
         undefined ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -69,8 +69,9 @@ wait_response(Mon, Timeout) ->
     receive
         {'DOWN', Mon, process, _Pid, Reason} ->
             error({cets_down, Reason});
-        {cets_reply, Mon, WaitInfo} ->
-            wait_for_updated(Mon, WaitInfo, Timeout)
+        {cets_ok, Mon} ->
+            erlang:demonitor(Mon, [flush]),
+            ok
     after Timeout ->
         erlang:demonitor(Mon, [flush]),
         flush_messages(Mon),

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -7,7 +7,7 @@
 -export([long_call/2, long_call/3]).
 -export([async_operation/2]).
 -export([sync_operation/2]).
--export([reply/2]).
+-export([reply/1]).
 
 -type request_id() :: cets:request_id().
 -type op() :: cets:op().
@@ -53,6 +53,6 @@ where({global, Name}) -> global:whereis_name(Name);
 where({local, Name}) -> whereis(Name);
 where({via, Module, Name}) -> Module:whereis_name(Name).
 
-reply(Alias, Reply) ->
+reply(Alias) ->
     %% Pid part is not used
-    gen_server:reply({x, [alias | Alias]}, Reply).
+    gen_server:reply({x, [alias | Alias]}, ok).

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -61,6 +61,10 @@ join2(_Info, LocalPid, RemotePid) ->
     %% We still use LocalPid/RemotePid in names
     %% (they are local and remote pids as passed from the cets_join and from the cets_discovery).
     #{opts := Opts} = cets:info(LocalPid),
+    %% Ensure that these two servers have processed any pending check_server requests
+    %% and their other_pids list is fully updated
+    cets:sync(LocalPid),
+    cets:sync(RemotePid),
     LocalOtherPids = cets:other_pids(LocalPid),
     RemoteOtherPids = cets:other_pids(RemotePid),
     LocPids = [LocalPid | LocalOtherPids],

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -159,16 +159,10 @@ aliases_for(Pid, Aliases) ->
     %% Pid we monitor
     %% Monitor to detect that we the remote server is down
     %% Alias to send messages from Pid to Pid2
-    Res = [
+    [
         {Pid2, Alias, find_destination(Pid, Pid2, Aliases)}
      || {Pid2, Alias} <- PidMons
-    ],
-    assert_aliases_are_different(Res),
-    Res.
-
-assert_aliases_are_different(Res) ->
-    [] = [X || {_, A, A, _} = X <- Res],
-    ok.
+    ].
 
 find_destination(Pid1, Pid2, Aliases) when Pid1 =/= Pid2 ->
     [Dest] = [Alias || {A, B, Alias} <- Aliases, A =:= Pid2, B =:= Pid1],

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -132,7 +132,7 @@ make_aliases(AllPids) ->
     [
         {Pid, Pid2, Alias}
      || Pid <- AllPids,
-        {Pid2, Alias} <- cets:make_alias_for(Pid, lists:delete(Pid, AllPids))
+        {Pid2, Alias} <- cets:make_aliases_for(Pid, lists:delete(Pid, AllPids))
     ].
 
 aliases_for(Pid, Aliases) ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -164,9 +164,10 @@ aliases_for(Pid, Aliases) ->
      || {Pid2, Alias} <- PidMons
     ].
 
-find_destination(Pid1, Pid2, Aliases) when Pid1 =/= Pid2 ->
-    [Dest] = [Alias || {A, B, Alias} <- Aliases, A =:= Pid2, B =:= Pid1],
-    Dest.
+find_destination(Pid1, Pid2, [{Pid2, Pid1, Alias} | _]) ->
+    Alias;
+find_destination(Pid1, Pid2, [_ | Aliases]) ->
+    find_destination(Pid1, Pid2, Aliases).
 
 maybe_apply_resolver(LocalDump, RemoteDump, Opts = #{handle_conflict := F}) ->
     Type = maps:get(type, Opts, ordered_set),

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -67,7 +67,7 @@ join2(_Info, LocalPid, RemotePid) ->
     RemPids = [RemotePid | RemoteOtherPids],
     Aliases = make_aliases(LocPids, RemPids) ++ make_aliases(RemPids, LocPids),
     AllPids = LocPids ++ RemPids,
-    Nums = maps:from_list(lists:zip(AllPids, lists:seq(1, length(AllPids)))),
+    Nums = maps:from_list(lists:zip(AllPids, lists:seq(0, length(AllPids) - 1))),
     Paused = [{Pid, cets:pause(Pid)} || Pid <- AllPids],
     %% Merges data from two partitions together.
     %% Each entry in the table is allowed to be updated by the node that owns

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -72,8 +72,8 @@ join2(_Info, LocalPid, RemotePid, Opts) ->
     #{opts := CetsOpts} = cets:info(LocalPid),
     %% Ensure that these two servers have processed any pending check_server requests
     %% and their other_pids list is fully updated
-    cets:sync(LocalPid),
-    cets:sync(RemotePid),
+    ok = cets:sync(LocalPid),
+    ok = cets:sync(RemotePid),
     LocalOtherPids = cets:other_pids(LocalPid),
     RemoteOtherPids = cets:other_pids(RemotePid),
     LocPids = [LocalPid | LocalOtherPids],
@@ -90,8 +90,8 @@ join2(_Info, LocalPid, RemotePid, Opts) ->
     %% Each entry in the table is allowed to be updated by the node that owns
     %% the key only, so merging is easy.
     Ref = make_ref(),
-    cets:sync(LocalPid),
-    cets:sync(RemotePid),
+    ok = cets:sync(LocalPid),
+    ok = cets:sync(RemotePid),
     {ok, LocalDump} = remote_or_local_dump(LocalPid),
     {ok, RemoteDump} = remote_or_local_dump(RemotePid),
     {LocalDump2, RemoteDump2} = maybe_apply_resolver(LocalDump, RemoteDump, CetsOpts),

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -4,6 +4,9 @@
 -export([join/5]).
 -include_lib("kernel/include/logger.hrl").
 
+%% Used in tests
+-ignore_xref([join/5]).
+
 -type lock_key() :: term().
 
 -spec join(lock_key(), cets_long:log_info(), pid(), pid()) -> ok | {error, term()}.

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -113,15 +113,14 @@ join2(_Info, LocalPid, RemotePid, Opts) ->
         AllPids
     ),
     %% Block till all the processes process apply_dump
-    [
+    Reasons = [
         receive
             {'DOWN', Mon, process, Pid, Reason} ->
-                Reason = normal
-        after timer:seconds(60) ->
-            error({apply_dump_timeout, Pid})
+                Reason
         end
      || {Pid, Mon} <- ApplyMons
     ],
+    [normal] = lists:usort(Reasons),
     %% Would be unpaused automatically after this process exits
     ok.
 

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -92,8 +92,8 @@ join2(_Info, LocalPid, RemotePid, Opts) ->
     Ref = make_ref(),
     ok = cets:sync(LocalPid),
     ok = cets:sync(RemotePid),
-    {ok, LocalDump} = remote_or_local_dump(LocalPid),
-    {ok, RemoteDump} = remote_or_local_dump(RemotePid),
+    {ok, LocalDump} = cets:remote_or_local_dump(LocalPid),
+    {ok, RemoteDump} = cets:remote_or_local_dump(RemotePid),
     {LocalDump2, RemoteDump2} = maybe_apply_resolver(LocalDump, RemoteDump, CetsOpts),
     %% Don't send dumps in parallel to not cause out-of-memory.
     %% It could be faster though.
@@ -155,14 +155,6 @@ assert_aliases_are_different(Res) ->
 find_destination(Pid1, Pid2, Aliases) when Pid1 =/= Pid2 ->
     [Dest] = [Alias || {A, B, Alias} <- Aliases, A =:= Pid2, B =:= Pid1],
     Dest.
-
-remote_or_local_dump(Pid) when node(Pid) =:= node() ->
-    {ok, Tab} = cets:table_name(Pid),
-    %% Reduce copying
-    {ok, cets:dump(Tab)};
-remote_or_local_dump(Pid) ->
-    %% We actually need to ask the remote process
-    cets:remote_dump(Pid).
 
 maybe_apply_resolver(LocalDump, RemoteDump, Opts = #{handle_conflict := F}) ->
     Type = maps:get(type, Opts, ordered_set),

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -111,6 +111,8 @@ join2(_Info, LocalPid, RemotePid, Opts) ->
     Send = fun(Pid, Dump) ->
         PauseRef = maps:get(Pid, Pid2PauseRef),
         NewServers = make_new_servers(Pid, Aliases),
+        Num = maps:get(Pid, Nums),
+        run_step({before_send_dump, Num, Pid}, Opts),
         cets:send_dump(Pid, DumpRef, PauseRef, Nums, NewServers, Dump)
     end,
     RemF = fun(Pid) -> Send(Pid, LocalDump2) end,

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -48,7 +48,13 @@ run_safely(Info, Fun) ->
             {error, {Class, Reason, Stacktrace}}
     after
         Diff = diff(Start),
-        ?LOG_INFO(Info#{what => long_task_finished, time_ms => Diff}),
+        case Diff > 50 of
+            true ->
+                ?LOG_INFO(Info#{what => long_task_finished, time_ms => Diff});
+            false ->
+                %% Do not log something really quick
+                ok
+        end,
         Pid ! stop
     end.
 

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -33,7 +33,7 @@ run_spawn(Info, F) ->
 run_safely(Info, Fun) ->
     Parent = self(),
     Start = erlang:system_time(millisecond),
-    ?LOG_INFO(Info#{what => long_task_started}),
+    ?LOG_DEBUG(Info#{what => long_task_started}),
     Pid = spawn_mon(Info, Parent, Start),
     try
         Fun()

--- a/src/cets_mon_cleaner.erl
+++ b/src/cets_mon_cleaner.erl
@@ -97,8 +97,8 @@ handle_erase(State) ->
     maps:foreach(fun send_down_all/2, State),
     maps:with(state_keys(), State).
 
-send_down_all(Mon, Pid) when is_reference(Mon) ->
-    Pid ! {cets_remote_down, Mon, all};
+send_down_all(Mon, _Pid) when is_reference(Mon) ->
+    Mon ! {cets_remote_down, Mon, all};
 send_down_all(_Key, _Val) ->
     true.
 
@@ -106,7 +106,7 @@ handle_remote_down(Num, State) ->
     maps:foreach(fun(K, V) -> send_remote_down(K, V, Num) end, State),
     State.
 
-send_remote_down(Mon, Pid, Num) when is_reference(Mon) ->
-    Pid ! {cets_remote_down, Mon, Num};
+send_remote_down(Mon, _Pid, Num) when is_reference(Mon) ->
+    Mon ! {cets_remote_down, Mon, Num};
 send_remote_down(_Key, _Val, _Num) ->
     true.

--- a/src/cets_mon_cleaner.erl
+++ b/src/cets_mon_cleaner.erl
@@ -6,7 +6,7 @@
 -module(cets_mon_cleaner).
 -behaviour(gen_server).
 
--export([start_link/2]).
+-export([start_link/1]).
 -export([
     init/1,
     handle_call/3,
@@ -18,26 +18,27 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--type timer_ref() :: reference().
 -type state() :: #{
-    mon_tab := atom(),
     interval := non_neg_integer(),
-    timer_ref := timer_ref()
+    timer_ref := reference(),
+    reference() => pid()
 }.
 
-start_link(Name, MonTab) ->
-    gen_server:start_link({local, Name}, ?MODULE, MonTab, []).
+state_keys() -> [interval, timer_ref].
 
--spec init(atom()) -> {ok, state()}.
-init(MonTab) ->
+start_link(Name) ->
+    gen_server:start_link({local, Name}, ?MODULE, false, []).
+
+init(_) ->
     Interval = 30000,
     State = #{
-        mon_tab => MonTab,
         interval => Interval,
         timer_ref => start_timer(Interval)
     },
     {ok, State}.
 
+handle_call(dump, _From, State) ->
+    {reply, maps:without(state_keys(), State), State};
 handle_call(Msg, From, State) ->
     ?LOG_ERROR(#{what => unexpected_call, msg => Msg, from => From}),
     {reply, {error, unexpected_call}, State}.
@@ -46,6 +47,14 @@ handle_cast(Msg, State) ->
     ?LOG_ERROR(#{what => unexpected_cast, msg => Msg}),
     {noreply, State}.
 
+handle_info({Mon, Pid}, State) when is_reference(Mon) ->
+    {noreply, maps:put(Mon, Pid, State)};
+handle_info(Mon, State) when is_reference(Mon) ->
+    {noreply, maps:remove(Mon, State)};
+handle_info({cets_remote_down, Num}, State) ->
+    {noreply, handle_remote_down(Num, State)};
+handle_info(erase, State) ->
+    {noreply, handle_erase(State)};
 handle_info(check, State) ->
     {noreply, handle_check(State)};
 handle_info(Msg, State) ->
@@ -75,17 +84,29 @@ start_timer(Interval) ->
     erlang:send_after(Interval, self(), check).
 
 -spec handle_check(state()) -> state().
-handle_check(State = #{mon_tab := MonTab}) ->
-    check_loop(ets:tab2list(MonTab), MonTab),
-    schedule_check(State).
+handle_check(State) ->
+    State2 = maps:filter(fun check_filter/2, State),
+    schedule_check(State2).
 
-check_loop([{Mon, Pid} | List], MonTab) ->
-    case is_process_alive(Pid) of
-        false ->
-            ets:delete(MonTab, Mon);
-        true ->
-            ok
-    end,
-    check_loop(List, MonTab);
-check_loop([], _MonTab) ->
-    ok.
+check_filter(Mon, Pid) when is_reference(Mon) ->
+    is_process_alive(Pid);
+check_filter(_Key, _Val) ->
+    true.
+
+handle_erase(State) ->
+    maps:foreach(fun send_down_all/2, State),
+    maps:with(state_keys(), State).
+
+send_down_all(Mon, Pid) when is_reference(Mon) ->
+    Pid ! {cets_remote_down, Mon, all};
+send_down_all(_Key, _Val) ->
+    true.
+
+handle_remote_down(Num, State) ->
+    maps:foreach(fun(K, V) -> send_remote_down(K, V, Num) end, State),
+    State.
+
+send_remote_down(Mon, Pid, Num) when is_reference(Mon) ->
+    Pid ! {cets_remote_down, Mon, Num};
+send_remote_down(_Key, _Val, _Num) ->
+    true.

--- a/src/cets_mon_cleaner.erl
+++ b/src/cets_mon_cleaner.erl
@@ -66,7 +66,7 @@ handle_erase(State) ->
     maps:with(state_keys(), State).
 
 send_down_all(Mon, _Val) when is_reference(Mon) ->
-    Mon ! {cets_ok, Mon};
+    cets_call:reply(Mon, ok);
 send_down_all(_Key, _Val) ->
     true.
 
@@ -79,7 +79,7 @@ handle_updated(Mon, Mask, State) ->
 handle_updated(Mon, Mask, State, Bits) when is_integer(Bits) ->
     case apply_mask(Mask, Bits) of
         0 ->
-            Mon ! {cets_ok, Mon},
+            cets_call:reply(Mon, ok),
             maps:remove(Mon, State);
         Bits2 ->
             State#{Mon := Bits2}

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -49,7 +49,8 @@ all() ->
         insert_into_keypos_table,
         info_contains_opts,
         updated_is_not_received_after_timeout,
-        remote_down_is_not_received_after_timeout
+        remote_down_is_not_received_after_timeout,
+        unknown_alias_in_check_server_message
     ].
 
 init_per_suite(Config) ->
@@ -670,6 +671,15 @@ remote_down_is_not_received_after_timeout(Config) ->
     %% Though, cets_mon_cleaner would probably receive delete request for
     %% the alias before.
     ensure_no_down_message().
+
+unknown_alias_in_check_server_message(Config) ->
+    {ok, Pid} = cets:start(make_name(Config, 1), #{}),
+    Source = self(),
+    Mon = make_ref(),
+    Dest = make_ref(),
+    DumpRef = make_ref(),
+    gen_server:cast(Pid, {check_server, Source, Mon, Dest, DumpRef}),
+    receive_message({'DOWN', Mon, process, Pid, check_server_failed}).
 
 start(Node, Tab) ->
     rpc(Node, cets, start, [Tab, #{}]).

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
         join_fails_before_apply_dump_with_partial_apply,
         join_fails_then_pending_ops_are_filtered,
         join_fails_then_old_alias_is_disabled,
+        pending_aliases_are_removed_after_unpause,
         apply_dump_with_unknown_dump_ref_would_be_ignored,
         test_multinode,
         node_list_is_correct,
@@ -358,6 +359,16 @@ join_fails_then_old_alias_is_disabled(Config) ->
     %% Ensure remote_op-s are received
     cets:ping(Pid1),
     {ok, [{z3}]} = cets:remote_dump(Pid1).
+
+pending_aliases_are_removed_after_unpause(Config) ->
+    {ok, Pid} = cets:start(make_name(Config, 1), #{}),
+    Ref = cets:pause(Pid),
+    Me = self(),
+    Aliases = cets:make_aliases_for(Pid, [Me]),
+    [{Me, _Alias}] = Aliases,
+    #{pending_aliases := Aliases} = cets:info(Pid),
+    ok = cets:unpause(Pid, Ref),
+    #{pending_aliases := []} = cets:info(Pid).
 
 apply_dump_with_unknown_dump_ref_would_be_ignored(Config) ->
     Me = self(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -38,6 +38,7 @@ all() ->
         write_returns_if_remote_server_crashes,
         write_returns_if_local_ack_process_crashes,
         ack_process_stops_correctly,
+        ack_process_handles_unknown_alias,
         sync_using_name_works,
         insert_many_request,
         insert_into_bag,
@@ -562,6 +563,13 @@ ack_process_stops_correctly(_Config) ->
         {'DOWN', AckMon, process, AckPid, normal} -> ok
     after 5000 -> ct:fail(timeout)
     end.
+
+ack_process_handles_unknown_alias(Config) ->
+    [Pid1, _Pid2] = join(make_n_servers(2, Config)),
+    #{ack_pid := AckPid} = cets:info(Pid1),
+    cets_ack:ack(AckPid, make_ref(), cets_bits:unset_flag_mask(42)),
+    %% Ack process still works fine
+    ok = cets:insert(Pid1, {1}).
 
 sync_using_name_works(_Config) ->
     {ok, _Pid1} = cets:start(c4, #{}),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -717,8 +717,8 @@ wait_response_fails_with_timeout(R) ->
 ensure_has_reply_message() ->
     receive
         %% From gen.erl
-        {[alias|Alias], _} ->
-           Alias
+        {[alias | Alias], _} ->
+            Alias
     after 0 -> ct:fail(no_incoming_reply)
     end.
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -630,6 +630,12 @@ remote_down_is_not_received_after_timeout(Config) ->
     Ref = erlang:monitor(process, Pid2),
     exit(Pid2, kill),
     receive_down_for_monitor(Ref),
+    cets:ping(Pid1),
+    %% The main reason we don't receive the message is that
+    %% we've demonitored after wait_response failed.
+    %% And cets_mon_cleaner would try to respond to our invalidated alias.
+    %% Though, cets_mon_cleaner would probably receive delete request for
+    %% the alias before.
     ensure_no_down_message().
 
 start(Node, Tab) ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -637,7 +637,7 @@ updated_is_received_after_timeout(Config) ->
     R = cets:insert_request(Pid1, {1}),
     wait_response_fails_with_timeout(R),
     sys:resume(Pid2),
-    %% Ensure that cets_updated message reaches us and filtered out
+    %% Ensure that cets_ack processed the reply
     cets:ping(Pid2),
     #{ack_pid := AckPid} = cets:info(Pid2),
     sys:get_state(AckPid),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -38,6 +38,7 @@ all() ->
         write_returns_if_remote_server_crashes,
         mon_cleaner_works,
         mon_cleaner_stops_correctly,
+        mon_cleaner_erase_unsets_all_pending_replies,
         sync_using_name_works,
         insert_many_request,
         insert_into_bag,

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -543,11 +543,11 @@ write_returns_if_remote_server_crashes(_Config) ->
 
 ack_process_stops_correctly(_Config) ->
     {ok, Pid} = cets:start(ack_stops, #{}),
-    #{mon_pid := MonPid} = cets:info(Pid),
-    MonMon = monitor(process, MonPid),
+    #{ack_pid := AckPid} = cets:info(Pid),
+    AckMon = monitor(process, AckPid),
     cets:stop(Pid),
     receive
-        {'DOWN', MonMon, process, MonPid, normal} -> ok
+        {'DOWN', AckMon, process, AckPid, normal} -> ok
     after 5000 -> ct:fail(timeout)
     end.
 
@@ -639,8 +639,8 @@ updated_is_received_after_timeout(Config) ->
     sys:resume(Pid2),
     %% Ensure that cets_updated message reaches us and filtered out
     cets:ping(Pid2),
-    #{mon_pid := MonPid} = cets:info(Pid2),
-    sys:get_state(MonPid),
+    #{ack_pid := AckPid} = cets:info(Pid2),
+    sys:get_state(AckPid),
     R = ensure_has_reply_message().
 
 remote_down_is_not_received_after_timeout(Config) ->


### PR DESCRIPTION
Changes for MIM-1960.

Concurrency fixes:
- Make joining more reliable. We disconnect from the servers which failed to apply the same dump.
- Assign integers to servers when joining. We could do it, because join is done when all nodes could talk to each other.
- Use bitmask when waiting for remote responses - Marginally faster, less garbage and we don't need to return a lot of pids from server.
- Add tests for joining. Use step function to simulate errors.
- **Use process aliases** everywhere.
- Use a separate process instead of mon_tab. Apparently, it allows to write faster (i.e. avoids ETS locks). And we don't really need all ETS table features there, we only wanna store monitors "just in case" one of the remote servers dies. We could store it inside our server, but it makes server to do more work = less throughput. On another hand, sending it to a separate process allows to use another core to handle maps:put/maps:delete operations. It also allows us to call servers remotely (i.e. `cets:insert(Pid, {1})`, where Pid is on the remote node.). Because removing a monitor is a message send operation, not `ets:delete`.
- User would not receive a delayed message after an operation timeout.
- Use standard `gen_server:call` to send requests to the local server. After that `cets_ack` would send us a reply, after all nodes in the cluster ack the operation.

Fix case when:
- join crashes/netsplits and only some servers have applied send_dump. I.e. the servers which applied send_dump would send remote_ops one-way.

Tweaks:
- don't use nosuspend, because it would not send a message if the dist socket is busy. We use async_dist=true instead. Otherwise we could use nosuspend, BUT with `spawn(fun() -> Pid ! Msg end)` if ok is not returned.
- `write_concurrency = true` for mon table - not that much difference though.
- `read_concurrency = true` for the data tables.


We do faster for when testing in parallel (16 benchee workers, 3 nodes):

```
Name             ips        average  deviation         median         99th %
cets          5.99 K      167.00 μs    ±24.20%      162.77 μs      280.81 μs
mnesia        4.80 K      208.26 μs    ±25.27%      198.50 μs      367.14 μs
```

Instead of when having no concurrency (1 benchee worker, 2 nodes):

```
mnesia       21.99 K       45.48 μs    ±28.28%       42.08 μs      108.96 μs
ets          21.89 K       45.68 μs    ±77.62%       43.31 μs       89.36 μs
cets         18.82 K       53.14 μs    ±27.83%       51.80 μs      105.80 μs
```

I.e. no concurrency is consistently 10-20% slower because we don't need to send extra messages to cets_ack and reply is returned directly. Though once we go to the real life scenario with at least 16 workers trying to write into the table, we start seeing lock contention in mnesia. (so, mnesia is a bit slower).

Still prefer having cets_ack to collect replies from the remote nodes, because we don't wanna do any work in the client process (i.e. we just keep gen_server:call api and all the distribution logic is outside of the caller process). If the process has non-empty queue, receiving messages would be probably slower even with selective receives (i.e. monitors) optimisation.


Also, cets_ack process is fast enough, i.e. adding a pool of cets_ack processes does not increase thoughput.




Code in the main branch tested (1 benchee worker, 2 nodes):

```
Name             ips        average  deviation         median         99th %
mnesia       22.37 K       44.70 μs    ±25.34%       41.97 μs      106.20 μs
ets          21.77 K       45.93 μs    ±24.87%       44.29 μs       84.56 μs
cets         19.24 K       51.97 μs    ±21.80%       50.49 μs       99.66 μs
```
Code in the main branch tested (16 benchee workers, 3 nodes):

```
Name             ips        average  deviation         median         99th %
cets          5.55 K      180.19 μs    ±29.33%      173.06 μs      342.94 μs
mnesia        5.14 K      194.54 μs    ±26.85%      187.34 μs      350.60 μs
```

(code used to test https://github.com/arcusfelis/cets_bench - careful, these tests have bad consistency, with 5-10% variation in ips between runs)

**Question: do we really need aliases to communicate between nodes?**
- Actually, just adding DumpRef value (last_applied_dump_ref in the state, assigned at join) to all remote_op-s and comparing it when receiving a remote op would filter out unwanted operations from the nodes, which failed to join. Though, it would not filter out messages from a node which disappeared, was cleaned after, and reappeared and still sends remote_op-s which are not wanted, but would have a valid DumpRef.
- With aliases unwanted remote_op-s would not be even copied into a message box, so it could help not to overload the process during a wild netsplit situation.
- We could check that: dump_ref is matching in the remote_ops and remote_op is from a pid from other_servers list. This means that once we cleanup after a node, we don't receive remote_ops even if node is back (unless it does the proper cets_join again, which would update dump_ref).

**Bit logic is cool idea but probably list operations would work as well**

# This PR should be split into two
- cets_mon_cleaner is replaced with cets_ack. gen_server:call API is used for operations. cets_bits magic is replaced with `lists:delete(RemotePid, OtherPids)`.
- cets_join tests. Aliases are cool, but this means join logic and cets state are more confusing = means more hidden bugs. Probably just setting dump_ref during the join and checking it is fine (and don't allow remote_ops after we handled a netsplit `DOWN` signal from a remote node).

