### PR TITLE
Add cets:insert_new operation

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -276,7 +276,7 @@ other_servers(Server) ->
 
 -spec get_leader(server_ref()) -> pid().
 get_leader(Server) ->
-    cets_call:long_call(Server, get_leader).
+    gen_server:call(Server, get_leader).
 
 %% Get a list of other nodes in the cluster that are connected together.
 -spec other_nodes(server_ref()) -> [node()].

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -22,6 +22,7 @@
     stop/1,
     insert/2,
     insert_many/2,
+    insert_new/2,
     delete/2,
     delete_many/2,
     delete_object/2,
@@ -34,6 +35,8 @@
     other_pids/1,
     pause/1,
     unpause/2,
+    get_leader/1,
+    set_leader/2,
     sync/1,
     ping/1,
     info/1,
@@ -57,12 +60,15 @@
     stop/1,
     insert/2,
     insert_many/2,
+    insert_new/2,
     delete/2,
     delete_many/2,
     delete_object/2,
     delete_objects/2,
     pause/1,
     unpause/2,
+    get_leader/1,
+    set_leader/2,
     sync/1,
     ping/1,
     info/1,
@@ -91,7 +97,9 @@
     | {delete_object, term()}
     | {insert_many, [tuple()]}
     | {delete_many, [term()]}
-    | {delete_objects, [term()]}.
+    | {delete_objects, [term()]}
+    | {insert_new, tuple()}
+    | {leader_op, op()}.
 -type from() :: {pid(), reference()}.
 -type backlog_entry() :: {op(), from()}.
 -type table_name() :: atom().
@@ -101,6 +109,8 @@
     mon_tab := atom(),
     mon_pid := pid(),
     other_servers := [pid()],
+    leader := pid(),
+    is_leader := boolean(),
     opts := start_opts(),
     backlog := [backlog_entry()],
     pause_monitors := [pause_monitor()]
@@ -115,6 +125,8 @@
     | get_info
     | other_servers
     | {unpause, reference()}
+    | get_leader
+    | {set_leader, boolean()}
     | {send_dump, [pid()], [tuple()]}.
 
 -type info() :: #{
@@ -128,11 +140,13 @@
 
 -type handle_down_fun() :: fun((#{remote_pid := pid(), table := table_name()}) -> ok).
 -type handle_conflict_fun() :: fun((tuple(), tuple()) -> tuple()).
+-type handle_wrong_leader() :: fun((term()) -> ok).
 -type start_opts() :: #{
     type => ordered_set | bag,
     keypos => non_neg_integer(),
     handle_down => handle_down_fun(),
-    handle_conflict => handle_conflict_fun()
+    handle_conflict => handle_conflict_fun(),
+    handle_wrong_leader => handle_wrong_leader()
 }.
 
 -export_type([request_id/0, op/0, server_ref/0, long_msg/0, info/0, table_name/0]).
@@ -196,6 +210,18 @@ insert(Server, Rec) when is_tuple(Rec) ->
 insert_many(Server, Records) when is_list(Records) ->
     cets_call:sync_operation(Server, {insert_many, Records}).
 
+%% Tries to insert a new record.
+%% All inserts are sent to the leader node first.
+%% It is a slightly slower comparing to just insert, because
+%% extra messaging is required.
+-spec insert_new(server_ref(), tuple()) -> WasInserted :: boolean().
+insert_new(Server, Rec) when is_tuple(Rec) ->
+    Res = cets_call:send_leader_op(Server, {insert_new, Rec}),
+    handle_insert_new_result(Res).
+
+handle_insert_new_result(ok) -> true;
+handle_insert_new_result({error, rejected}) -> false.
+
 %% Removes an object with the key from all nodes in the cluster.
 %% Ideally, nodes should only remove data that they've inserted, not data from other node.
 -spec delete(server_ref(), term()) -> ok.
@@ -248,6 +274,10 @@ wait_response(Mon, Timeout) ->
 other_servers(Server) ->
     cets_call:long_call(Server, other_servers).
 
+-spec get_leader(server_ref()) -> pid().
+get_leader(Server) ->
+    cets_call:long_call(Server, get_leader).
+
 %% Get a list of other nodes in the cluster that are connected together.
 -spec other_nodes(server_ref()) -> [node()].
 other_nodes(Server) ->
@@ -265,6 +295,13 @@ pause(Server) ->
 -spec unpause(server_ref(), pause_monitor()) -> ok | {error, unknown_pause_monitor}.
 unpause(Server, PauseRef) ->
     cets_call:long_call(Server, {unpause, PauseRef}).
+
+%% Set is_leader field in the state.
+%% For debugging only.
+%% Setting in in the real life would break leader election logic.
+-spec set_leader(server_ref(), boolean()) -> ok.
+set_leader(Server, IsLeader) ->
+    cets_call:long_call(Server, {set_leader, IsLeader}).
 
 %% Waits till all pending operations are applied.
 -spec sync(server_ref()) -> ok.
@@ -296,6 +333,8 @@ init({Tab, Opts}) ->
         mon_tab => MonTab,
         mon_pid => MonPid,
         other_servers => [],
+        leader => self(),
+        is_leader => true,
         opts => Opts,
         backlog => [],
         pause_monitors => []
@@ -305,6 +344,8 @@ init({Tab, Opts}) ->
     {noreply, state()} | {reply, term(), state()}.
 handle_call(other_servers, _From, State = #{other_servers := Servers}) ->
     {reply, Servers, State};
+handle_call(get_leader, _From, State = #{leader := Leader}) ->
+    {reply, Leader, State};
 handle_call(sync, From, State = #{other_servers := Servers}) ->
     %% Do spawn to avoid any possible deadlocks
     proc_lib:spawn(fun() ->
@@ -328,6 +369,8 @@ handle_call(pause, _From = {FromPid, _}, State = #{pause_monitors := Mons}) ->
     {reply, Mon, State#{pause_monitors := [Mon | Mons]}};
 handle_call({unpause, Ref}, _From, State) ->
     handle_unpause(Ref, State);
+handle_call({set_leader, IsLeader}, _From, State) ->
+    {reply, ok, State#{is_leader := IsLeader}};
 handle_call(get_info, _From, State) ->
     handle_get_info(State).
 
@@ -364,7 +407,7 @@ code_change(_OldVsn, State, _Extra) ->
 handle_send_dump(NewPids, Dump, State = #{tab := Tab, other_servers := Servers}) ->
     ets:insert(Tab, Dump),
     Servers2 = add_servers(NewPids, Servers),
-    {reply, ok, State#{other_servers := Servers2}}.
+    {reply, ok, set_other_servers(Servers2, State)}.
 
 handle_down(Mon, Pid, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
@@ -386,7 +429,7 @@ handle_down2(_Mon, RemotePid, State = #{other_servers := Servers, mon_tab := Mon
             Servers2 = lists:delete(RemotePid, Servers),
             notify_remote_down(RemotePid, MonTab),
             call_user_handle_down(RemotePid, State),
-            {noreply, State#{other_servers := Servers2}};
+            {noreply, set_other_servers(Servers2, State)};
         false ->
             %% This should not happen
             ?LOG_ERROR(#{
@@ -429,6 +472,16 @@ add_servers2(SelfPid, [RemotePid | OtherPids], Servers) when is_pid(RemotePid) -
     end;
 add_servers2(_SelfPid, [], _Servers) ->
     [].
+
+%% Sets other_servers field, chooses the leader
+set_other_servers(Servers, State) ->
+    %% Choose process with highest pid.
+    %% Uses total ordering of terms in Erlang
+    %% (so all nodes would choose the same leader).
+    %% The leader node would not receive that much extra load.
+    Leader = lists:max([self() | Servers]),
+    IsLeader = Leader =:= self(),
+    State#{leader := Leader, is_leader := IsLeader, other_servers := Servers}.
 
 pids_to_nodes(Pids) ->
     lists:map(fun node/1, Pids).
@@ -475,13 +528,38 @@ do_table_op({insert_many, Recs}, Tab) ->
 do_table_op({delete_many, Keys}, Tab) ->
     ets_delete_keys(Tab, Keys);
 do_table_op({delete_objects, Objects}, Tab) ->
-    ets_delete_objects(Tab, Objects).
+    ets_delete_objects(Tab, Objects);
+do_table_op({insert_new, Rec}, Tab) ->
+    ets:insert_new(Tab, Rec).
 
 %% Handle operation locally and replicate it across the cluster
+handle_op(From, {leader_op, Msg}, State) ->
+    handle_leader_op(From, Msg, State);
 handle_op(From = {Mon, Pid}, Msg, State) when is_pid(Pid) ->
     do_op(Msg, State),
     WaitInfo = replicate(Pid, From, Msg, State),
     Pid ! {cets_reply, Mon, WaitInfo},
+    ok.
+
+handle_leader_op(From = {Mon, Pid}, Msg, State = #{is_leader := true}) ->
+    case do_op(Msg, State) of
+        false -> %% Skip the replication - insert_new returns false.
+            Pid ! {cets_reply, Mon, false, {error, rejected}};
+        true ->
+            WaitInfo = replicate(Pid, From, Msg, State),
+            Pid ! {cets_reply, Mon, WaitInfo}
+    end;
+handle_leader_op(From = {Mon, Pid}, Msg, State) ->
+    %% Reject operation - not a leader
+    Pid ! {cets_reply, Mon, false, {error, wrong_leader}},
+    handle_wrong_leader(From, Msg, State).
+
+handle_wrong_leader(From, Msg, _State = #{opts := #{handle_wrong_leader := F}}) ->
+    %% It is used for debugging/logging
+    %% Do not do anything heavy here
+    catch F(#{from => From, msg => Msg, server => self()}),
+    ok;
+handle_wrong_leader(_State, _From, _Msg) ->
     ok.
 
 replicate(Pid, From, Msg, #{mon_tab := MonTab, other_servers := Servers}) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -151,6 +151,12 @@
 
 -export_type([request_id/0, op/0, server_ref/0, long_msg/0, info/0, table_name/0]).
 
+-type local_mon_tab() :: atom().
+-type remote_mon_tab() :: {remote, node(), local_mon_tab()}.
+-type local_or_remote_mon_tab() :: local_mon_tab() | remote_mon_tab().
+-type wait_info() :: {Servers :: [pid()], MonTabInfo :: local_or_remote_mon_tab()}.
+-export_type([wait_info/0, local_or_remote_mon_tab/0]).
+
 %% API functions
 
 %% Table and server has the same name
@@ -571,6 +577,7 @@ handle_wrong_leader(From, Msg, _State = #{opts := #{handle_wrong_leader := F}}) 
 handle_wrong_leader(_State, _From, _Msg) ->
     ok.
 
+-spec replicate(pid(), {reference(), pid()}, op(), state()) -> wait_info().
 replicate(Pid, From, Msg, #{mon_tab := MonTab, other_servers := Servers}) ->
     %% Reply would be routed directly to FromPid
     Msg2 = {remote_op, From, Msg},

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -146,11 +146,8 @@ send_leader_op(Server, Op, Backoff) ->
     case Res of
         {error, wrong_leader} ->
             ?LOG_WARNING(#{what => wrong_leader, server => Server, operation => Op}),
-            %% We are free to retry
-            %% While it is infinite retries, the leader election logic is simple.
-            %% The only issue could be if there are bugs in the leader election logic
-            %% (i.e. our server thinks there is one leader in the cluster,
-            %% while that leader has another leader selected - i.e. an impossible case)
+            %% This could happen if a new node joins the cluster.
+            %% So, a simple retry should help.
             case Backoff of
                 [Milliseconds | NextBackoff] ->
                     timer:sleep(Milliseconds),

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -92,7 +92,8 @@ wait_for_updated(Mon, {Servers, MonTab}) ->
         delete_from_mon_tab(MonTab, Mon)
     end;
 wait_for_updated(Mon, false) ->
-    erlang:demonitor(Mon, [flush]), %% not replicated
+    %% not replicated
+    erlang:demonitor(Mon, [flush]),
     ok.
 
 %% Edgecase: special treatment if Server is on the remote node
@@ -140,7 +141,9 @@ send_leader_op(Server, Op) ->
             %% The only issue could be if there are bugs in the leader election logic
             %% (i.e. our server thinks there is one leader in the cluster,
             %% while that leader has another leader selected - i.e. an impossible case)
-            send_leader_op(Server, Op); %% Retry
+
+            %% Retry
+            send_leader_op(Server, Op);
         _ ->
             Res
     end.

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -83,8 +83,14 @@ wait_for_updated(Mon, {Servers, MonTab}) ->
         do_wait_for_updated(Mon, Servers)
     after
         erlang:demonitor(Mon, [flush]),
-        ets:delete(MonTab, Mon)
+        delete_from_mon_tab(MonTab, Mon)
     end.
+
+%% Edgecase: special treatment if Server is on the remote node
+delete_from_mon_tab({remote, Node, MonTab}, Mon) ->
+    rpc:async_call(Node, ets, delete, [MonTab, Mon]);
+delete_from_mon_tab(MonTab, Mon) ->
+    ets:delete(MonTab, Mon).
 
 do_wait_for_updated(_Mon, []) ->
     ok;

--- a/src/cets_metadata.erl
+++ b/src/cets_metadata.erl
@@ -1,0 +1,16 @@
+-module(cets_metadata).
+-export([init/1,
+         set/3,
+         get/2]).
+
+init(Name) ->
+    ets:new(name(Name), [named_table, public, {read_concurrency, true}]).
+
+set(Name, K, V) ->
+    ets:insert(name(Name), {K, V}).
+
+get(Name, K) ->
+    ets:lookup_element(name(Name), K, 2).
+
+name(Name) ->
+    list_to_atom("md_" ++ atom_to_list(Name)).

--- a/src/cets_metadata.erl
+++ b/src/cets_metadata.erl
@@ -1,10 +1,14 @@
 -module(cets_metadata).
--export([init/1,
-         set/3,
-         get/2]).
+-export([
+    init/1,
+    set/3,
+    get/2
+]).
 
 init(Name) ->
-    ets:new(name(Name), [named_table, public, {read_concurrency, true}]).
+    FullName = name(Name),
+    FullName = ets:new(FullName, [named_table, public, {read_concurrency, true}]),
+    ok.
 
 set(Name, K, V) ->
     ets:insert(name(Name), {K, V}).

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -20,6 +20,7 @@ all() ->
         bag_with_conflict_handler_not_allowed,
         join_with_the_same_pid,
         test_multinode,
+        test_multinode_remote_insert,
         node_list_is_correct,
         test_multinode_auto_discovery,
         test_locally,
@@ -229,6 +230,17 @@ test_multinode(Config) ->
     delete_many(Node4, Tab, [a, n]),
     Same([{b}, {c}, {d}, {f}, {m}, {y}]),
     ok.
+
+test_multinode_remote_insert(Config) ->
+    Tab = rem_tab,
+    [Node2, Node3 | _] = proplists:get_value(nodes, Config),
+    {ok, Pid2} = start(Node2, Tab),
+    {ok, Pid3} = start(Node3, Tab),
+    ok = join(Node2, Tab, Pid2, Pid3),
+    true = node() =/= node(Pid2), %% Ensure it is a remote node
+    %% Insert without calling rpc module
+    cets:insert(Pid2, {a}),
+    [{a}] = dump(Node3, Tab).
 
 node_list_is_correct(Config) ->
     Node1 = node(),


### PR DESCRIPTION
This operation uses one node in the cluster to verify that the inserted record is new.

# Reasoning

It is needed for mod_muc, because it tries to use room-name as a key.
There is a chance the room would be registered twice, so a transaction would be needed.
But insert-new looks like more simple solution (i.e. no need to invent locks for transaction).

# How it works

- we choose one node in the cluster where we would send an initial request.
- this node calls ets:insert_new and replicates the changes. 
- if ets:insert_new returns false - it does not replicate the changes and replies to the caller with `false` instead of `true`.

- We need to call `rpc:async_call(Node, ets, delete, [MonTab, Mon]);` to remove reference from the mon_tab... 


There is not much difference between insert and insert_new (2 nodes, 1 thread to test):

```
Name               ips        average  deviation         median         99th %
mnesia         21.90 K       45.65 μs    ±24.98%       42.80 μs      106.23 μs
ets            20.95 K       47.73 μs    ±76.92%       45.07 μs      100.62 μs
cets           19.65 K       50.89 μs    ±21.38%       50.28 μs       99.67 μs
cets_new       18.96 K       52.74 μs    ±29.13%       51.81 μs      101.72 μs
```