### PR TITLE
Make CETS joining logic more reliable

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -289,7 +289,7 @@ other_nodes(Server) ->
     lists:usort(pids_to_nodes(other_pids(Server))).
 
 %% Get a list of other CETS processes that are handling this table.
--spec other_pids(server_ref()) -> [server_pid()] | {error, term()}.
+-spec other_pids(server_ref()) -> [server_pid()].
 other_pids(Server) ->
     cets_call:long_call(Server, other_servers).
 
@@ -670,7 +670,8 @@ call_user_handle_down(RemotePid, #{tab := Tab, opts := Opts}) ->
                 remote_pid => RemotePid,
                 remote_node => node(RemotePid)
             },
-            cets_long:run_safely(Info, FF);
+            %% Errors would be logged inside run_tracked
+            catch cets_long:run_tracked(Info, FF);
         _ ->
             ok
     end.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -514,6 +514,7 @@ handle_remote_op(Op, From, AckPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
         join_ref => JoinRef,
         msg => Msg
     }),
+    %% We still need to reply to the remote process so it could stop waiting
     cets_ack:ack(AckPid, From, self()).
 
 %% Apply operation for one local table only

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -423,11 +423,12 @@ handle_send_dump(NewPids, JoinRef, Dump, State = #{tab := Tab, other_servers := 
 handle_down(Mon, Pid, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
         true ->
-            ?LOG_ERROR(#{
+            Log = #{
                 what => pause_owner_crashed,
                 state => State,
                 paused_by_pid => Pid
-            }),
+            },
+            ?LOG_ERROR(Log),
             handle_unpause2(Mon, Mons, State);
         false ->
             handle_down2(Pid, State)
@@ -443,11 +444,12 @@ handle_down2(RemotePid, State = #{other_servers := Servers, ack_pid := AckPid}) 
             set_other_servers(Servers2, State);
         false ->
             %% This should not happen
-            ?LOG_ERROR(#{
+            Log = #{
                 what => handle_down_failed,
                 remote_pid => RemotePid,
                 state => State
-            }),
+            },
+            ?LOG_ERROR(Log),
             State
     end.
 
@@ -465,11 +467,12 @@ add_servers2(SelfPid, [RemotePid | OtherPids], Servers) when is_pid(RemotePid) -
             erlang:monitor(process, RemotePid),
             [RemotePid | add_servers2(SelfPid, OtherPids, Servers)];
         true ->
-            ?LOG_INFO(#{
+            Log = #{
                 what => already_added,
                 remote_pid => RemotePid,
                 remote_node => node(RemotePid)
-            }),
+            },
+            ?LOG_INFO(Log),
             add_servers2(SelfPid, OtherPids, Servers)
     end;
 add_servers2(_SelfPid, [], _Servers) ->
@@ -510,13 +513,14 @@ handle_remote_op(Op, From, AckPid, JoinRef, State = #{join_ref := JoinRef}) ->
     do_op(Op, State),
     cets_ack:ack(AckPid, From, self());
 handle_remote_op(Op, From, AckPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
-    ?LOG_ERROR(#{
+    Log = #{
         what => drop_remote_op,
         from => From,
         remote_join_ref => RemoteJoinRef,
         join_ref => JoinRef,
         op => Op
-    }),
+    },
+    ?LOG_ERROR(Log),
     %% We still need to reply to the remote process so it could stop waiting
     cets_ack:ack(AckPid, From, self()).
 
@@ -626,13 +630,14 @@ send_check_server(Pid, JoinRef) ->
 handle_check_server(_FromPid, JoinRef, #{join_ref := JoinRef}) ->
     ok;
 handle_check_server(FromPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
-    ?LOG_WARNING(#{
+    Log = #{
         what => cets_check_server_failed,
         text => <<"Disconnect the remote server">>,
         remote_pid => FromPid,
         remote_join_ref => RemoteJoinRef,
         join_ref => JoinRef
-    }),
+    },
+    ?LOG_WARNING(Log),
     %% Ask the remote server to disconnect from us
     Reason = {check_server_failed, {RemoteJoinRef, JoinRef}},
     FromPid ! {'DOWN', make_ref(), process, self(), Reason},

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -68,13 +68,14 @@ send_leader_op(Server, Op, Backoff) ->
     Res = sync_operation(Leader, {leader_op, Op}),
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
-            ?LOG_WARNING(#{
+            Log = #{
                 what => wrong_leader,
                 server => Server,
                 operation => Op,
                 called_leader => Leader,
                 expected_leader => ExpectedLeader
-            }),
+            },
+            ?LOG_WARNING(Log),
             %% This could happen if a new node joins the cluster.
             %% So, a simple retry should help.
             case Backoff of

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -29,9 +29,9 @@ long_call(Server, Msg, Info) ->
         Pid when is_pid(Pid) ->
             Info2 = Info#{server => Server, pid => Pid, node => node(Pid)},
             F = fun() -> gen_server:call(Pid, Msg, infinity) end,
-            cets_long:run_safely(Info2, F);
+            cets_long:run_tracked(Info2, F);
         undefined ->
-            {error, pid_not_found}
+            error({pid_not_found, Server})
     end.
 
 %% Contacts the local server to broadcast multinode operation.

--- a/src/cets_discovery_file.erl
+++ b/src/cets_discovery_file.erl
@@ -23,11 +23,12 @@ init(Opts) ->
 get_nodes(State = #{disco_file := Filename}) ->
     case file:read_file(Filename) of
         {error, Reason} ->
-            ?LOG_ERROR(#{
+            Log = #{
                 what => discovery_failed,
                 filename => Filename,
                 reason => Reason
-            }),
+            },
+            ?LOG_ERROR(Log),
             {{error, Reason}, State};
         {ok, Text} ->
             Lines = binary:split(Text, [<<"\r">>, <<"\n">>, <<" ">>], [global]),

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -187,11 +187,12 @@ check_fully_connected(Pids) ->
         true ->
             check_same_join_ref(Pids);
         false ->
-            ?LOG_ERROR(#{
+            Log = #{
                 what => check_fully_connected_failed,
                 expected_pids => Pids,
                 server_lists => Lists
-            }),
+            },
+            ?LOG_ERROR(Log),
             error(check_fully_connected_failed)
     end.
 
@@ -207,10 +208,11 @@ check_same_join_ref(Pids) ->
         [_] ->
             ok;
         _ ->
-            ?LOG_ERROR(#{
+            Log = #{
                 what => check_same_join_ref_failed,
                 refs => lists:zip(Pids, Refs)
-            }),
+            },
+            ?LOG_ERROR(Log),
             error(check_same_join_ref_failed)
     end.
 

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -89,6 +89,7 @@ join2(_Info, LocalPid, RemotePid, JoinOpts) ->
         lists:foreach(RemF, RemPids),
         ok
     after
+        run_step(before_unpause, JoinOpts),
         lists:foreach(fun({Pid, Ref}) -> cets:unpause(Pid, Ref) end, Paused)
     end.
 

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -10,6 +10,7 @@
 -type step() ::
     join_start
     | before_retry
+    | before_get_pids
     | before_check_fully_connected
     | before_unpause
     | {before_send_dump, cets:server_pid()}.
@@ -81,6 +82,7 @@ join2(_Info, LocalPid, RemotePid, JoinOpts) ->
     %% We still use LocalPid/RemotePid in names
     %% (they are local and remote pids as passed from the cets_join and from the cets_discovery).
     #{opts := Opts} = cets:info(LocalPid),
+    run_step(before_get_pids, JoinOpts),
     LocPids = get_pids(LocalPid),
     RemPids = get_pids(RemotePid),
     run_step(before_check_fully_connected, JoinOpts),

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -1,34 +1,41 @@
 %% @doc Cluster join logic.
 -module(cets_join).
 -export([join/4]).
+-export([join/5]).
 -include_lib("kernel/include/logger.hrl").
 
 -type lock_key() :: term().
+
+-ignore_xref([join/5]).
 
 %% Adds a node to a cluster.
 %% Writes from other nodes would wait for join completion.
 %% LockKey should be the same on all nodes.
 -spec join(lock_key(), cets_long:log_info(), pid(), pid()) -> ok | {error, term()}.
-join(LockKey, Info, LocalPid, RemotePid) when is_pid(LocalPid), is_pid(RemotePid) ->
+join(LockKey, Info, LocalPid, RemotePid) ->
+    join(LockKey, Info, LocalPid, RemotePid, #{}).
+
+-spec join(lock_key(), cets_long:log_info(), pid(), pid(), #{}) -> ok | {error, term()}.
+join(LockKey, Info, LocalPid, RemotePid, JoinOpts) when is_pid(LocalPid), is_pid(RemotePid) ->
     Info2 = Info#{
         local_pid => LocalPid,
         remote_pid => RemotePid,
         remote_node => node(RemotePid)
     },
-    F = fun() -> join1(LockKey, Info2, LocalPid, RemotePid) end,
+    F = fun() -> join1(LockKey, Info2, LocalPid, RemotePid, JoinOpts) end,
     cets_long:run_safely(Info2#{long_task_name => join}, F).
 
-join1(LockKey, Info, LocalPid, RemotePid) ->
+join1(LockKey, Info, LocalPid, RemotePid, JoinOpts) ->
     OtherPids = cets:other_pids(LocalPid),
     case lists:member(RemotePid, OtherPids) of
         true ->
             {error, already_joined};
         false ->
             Start = erlang:system_time(millisecond),
-            join_loop(LockKey, Info, LocalPid, RemotePid, Start)
+            join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts)
     end.
 
-join_loop(LockKey, Info, LocalPid, RemotePid, Start) ->
+join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts) ->
     %% Only one join at a time:
     %% - for performance reasons, we don't want to cause too much load for active nodes
     %% - to avoid deadlocks, because joining does gen_server calls
@@ -38,7 +45,7 @@ join_loop(LockKey, Info, LocalPid, RemotePid, Start) ->
         %% overloaded or joining is already in progress on another node
         ?LOG_INFO(Info#{what => join_got_lock, after_time_ms => Diff}),
         %% Do joining in a separate process to reduce GC
-        cets_long:run_spawn(Info, fun() -> join2(Info, LocalPid, RemotePid) end)
+        cets_long:run_spawn(Info, fun() -> join2(Info, LocalPid, RemotePid, JoinOpts) end)
     end,
     LockRequest = {LockKey, self()},
     %% Just lock all nodes, no magic here :)
@@ -47,12 +54,12 @@ join_loop(LockKey, Info, LocalPid, RemotePid, Start) ->
     case global:trans(LockRequest, F, Nodes, Retries) of
         aborted ->
             ?LOG_ERROR(Info#{what => join_retry, reason => lock_aborted}),
-            join_loop(LockKey, Info, LocalPid, RemotePid, Start);
+            join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts);
         Result ->
             Result
     end.
 
-join2(_Info, LocalPid, RemotePid) ->
+join2(_Info, LocalPid, RemotePid, JoinOpts) ->
     %% Joining is a symmetrical operation here - both servers exchange information between each other.
     %% We still use LocalPid/RemotePid in names
     %% (they are local and remote pids as passed from the cets_join and from the cets_discovery).
@@ -72,14 +79,18 @@ join2(_Info, LocalPid, RemotePid) ->
         {ok, LocalDump} = remote_or_local_dump(LocalPid),
         {ok, RemoteDump} = remote_or_local_dump(RemotePid),
         {LocalDump2, RemoteDump2} = maybe_apply_resolver(LocalDump, RemoteDump, Opts),
-        RemF = fun(Pid) -> cets:send_dump(Pid, LocPids, LocalDump2) end,
-        LocF = fun(Pid) -> cets:send_dump(Pid, RemPids, RemoteDump2) end,
-        lists:foreach(RemF, RemPids),
+        RemF = fun(Pid) -> send_dump(Pid, LocPids, LocalDump2, JoinOpts) end,
+        LocF = fun(Pid) -> send_dump(Pid, RemPids, RemoteDump2, JoinOpts) end,
         lists:foreach(LocF, LocPids),
+        lists:foreach(RemF, RemPids),
         ok
     after
         lists:foreach(fun({Pid, Ref}) -> cets:unpause(Pid, Ref) end, Paused)
     end.
+
+send_dump(Pid, Pids, Dump, JoinOpts) ->
+    run_step({before_send_dump, Pid}, JoinOpts),
+    cets:send_dump(Pid, Pids, Dump).
 
 remote_or_local_dump(Pid) when node(Pid) =:= node() ->
     {ok, Tab} = cets:table_name(Pid),
@@ -129,3 +140,8 @@ apply_resolver_for_sorted(
     end;
 apply_resolver_for_sorted(LocalDump, RemoteDump, _F, _Pos, LocalAcc, RemoteAcc) ->
     {lists:reverse(LocalAcc, LocalDump), lists:reverse(RemoteAcc, RemoteDump)}.
+
+run_step(Step, #{step_handler := F}) ->
+    F(Step);
+run_step(_Step, _Opts) ->
+    ok.

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -50,12 +50,13 @@ run_tracked(Info, Fun) ->
         Fun()
     catch
         Class:Reason:Stacktrace ->
-            ?LOG_ERROR(Info#{
+            Log = Info#{
                 what => long_task_failed,
                 class => Class,
                 reason => Reason,
                 stacktrace => Stacktrace
-            }),
+            },
+            ?LOG_ERROR(Log),
             erlang:raise(Class, Reason, Stacktrace)
     after
         Diff = diff(Start),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -402,7 +402,7 @@ join_fails_because_server_process_not_found(Config) ->
         (_) ->
             ok
     end,
-    {error, {error, _, _}} =
+    {error, {noproc, {gen_server, call, [Pid1, get_info, infinity]}}} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}).
 
 join_fails_because_server_process_not_found_before_get_pids(Config) ->
@@ -414,7 +414,7 @@ join_fails_because_server_process_not_found_before_get_pids(Config) ->
         (_) ->
             ok
     end,
-    {error, {error, {get_other_pids_failed, Pid1, _}, _}} =
+    {error, {noproc, {gen_server, call, [Pid1, other_servers, infinity]}}} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}).
 
 join_fails_before_send_dump(Config) ->
@@ -434,7 +434,7 @@ join_fails_before_send_dump(Config) ->
         (_) ->
             ok
     end,
-    {error, {error, sim_error, _}} =
+    {error, sim_error} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
     %% Ensure we sent dump to Pid1
     receive_message(before_send_dump_called_for_pid1),
@@ -470,7 +470,7 @@ join_fails_before_send_dump_and_there_are_pending_remote_ops(Config) ->
         (_) ->
             ok
     end,
-    {error, {error, sim_error2, _}} =
+    {error, sim_error2} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
     %% Ensure we sent dump to Pid1
     receive_message(before_send_dump_called_for_pid1),
@@ -530,7 +530,7 @@ join_fails_in_check_fully_connected(Config) ->
         (_) ->
             ok
     end,
-    {error, {error, check_fully_connected_failed, _}} =
+    {error, check_fully_connected_failed} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
     receive_message(before_check_fully_connected_called).
 
@@ -543,7 +543,7 @@ join_fails_because_join_refs_do_not_match_for_nodes_in_segment(Config) ->
     %% (probably could happen if it still haven't checked other nodes after a join)
     ok = cets_join:join(lock_name(Config), #{}, Pid2, Pid3, #{}),
     set_join_ref(Pid3, make_ref()),
-    {error, {error, check_same_join_ref_failed, _}} =
+    {error, check_same_join_ref_failed} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}).
 
 join_fails_because_pids_do_not_match_for_nodes_in_segment(Config) ->
@@ -555,7 +555,7 @@ join_fails_because_pids_do_not_match_for_nodes_in_segment(Config) ->
     %% (probably could happen if it still haven't checked other nodes after a join)
     ok = cets_join:join(lock_name(Config), #{}, Pid2, Pid3, #{}),
     set_other_servers(Pid3, []),
-    {error, {error, check_fully_connected_failed, _}} =
+    {error, check_fully_connected_failed} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}).
 
 remote_ops_are_ignored_if_join_ref_does_not_match(Config) ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -29,6 +29,7 @@ all() ->
         insert_new_fails_if_the_local_server_is_dead,
         leader_is_the_same_in_metadata_after_join,
         join_with_the_same_pid,
+        join_ref_is_same_after_join,
         join_fails_before_send_dump,
         test_multinode,
         test_multinode_remote_insert,
@@ -375,6 +376,13 @@ join_with_the_same_pid(_Config) ->
     Nodes = [node()],
     %% The process is still running and no data loss (i.e. size is not zero)
     #{nodes := Nodes, size := 1} = cets:info(Pid).
+
+join_ref_is_same_after_join(Config) ->
+    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
+    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}),
+    #{join_ref := JoinRef} = cets:info(Pid1),
+    #{join_ref := JoinRef} = cets:info(Pid2).
 
 join_fails_before_send_dump(Config) ->
     Me = self(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -73,7 +73,8 @@ all() ->
         unknown_cast_message_is_ignored_in_ack_process,
         unknown_call_returns_error_from_ack_process,
         code_change_returns_ok,
-        code_change_returns_ok_for_ack
+        code_change_returns_ok_for_ack,
+        run_spawn_forwards_errors
     ].
 
 init_per_suite(Config) ->
@@ -955,6 +956,15 @@ code_change_returns_ok_for_ack(_Config) ->
     sys:suspend(AckPid),
     ok = sys:change_code(AckPid, cets_ack, v2, []),
     sys:resume(AckPid).
+
+run_spawn_forwards_errors(_Config) ->
+    matched =
+        try
+            cets_long:run_spawn(#{}, fun() -> error(oops) end)
+        catch
+            error:oops ->
+                matched
+        end.
 
 still_works(Pid) ->
     pong = cets:ping(Pid),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -406,7 +406,7 @@ join_fails_because_server_process_not_found(Config) ->
             ok
     end,
     {error, {noproc, {gen_server, call, [Pid1, get_info, infinity]}}} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}).
+        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
 
 join_fails_because_server_process_not_found_before_get_pids(Config) ->
     {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
@@ -418,7 +418,7 @@ join_fails_because_server_process_not_found_before_get_pids(Config) ->
             ok
     end,
     {error, {noproc, {gen_server, call, [Pid1, other_servers, infinity]}}} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}).
+        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
 
 join_fails_before_send_dump(Config) ->
     Me = self(),
@@ -438,7 +438,7 @@ join_fails_before_send_dump(Config) ->
             ok
     end,
     {error, sim_error} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
+        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
     %% Ensure we sent dump to Pid1
     receive_message(before_send_dump_called_for_pid1),
     %% Not joined, some data exchanged
@@ -474,7 +474,7 @@ join_fails_before_send_dump_and_there_are_pending_remote_ops(Config) ->
             ok
     end,
     {error, sim_error2} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
+        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
     %% Ensure we sent dump to Pid1
     receive_message(before_send_dump_called_for_pid1),
     cets:insert_request(Pid1, {1}),
@@ -505,7 +505,7 @@ send_dump_fails_during_join_because_receiver_exits(Config) ->
         (_) ->
             ok
     end,
-    ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
+    ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
     receive_message(before_send_dump_called),
     pong = cets:ping(Pid1),
     receive_message({down_called, Pid1, Pid2}),
@@ -534,7 +534,7 @@ join_fails_in_check_fully_connected(Config) ->
             ok
     end,
     {error, check_fully_connected_failed} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{step_handler => F}),
+        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
     receive_message(before_check_fully_connected_called).
 
 join_fails_because_join_refs_do_not_match_for_nodes_in_segment(Config) ->
@@ -600,12 +600,12 @@ join_retried_if_lock_is_busy(Config) ->
     end,
     %% Get the lock in a separate process
     spawn_link(fun() ->
-        cets_join:join(Lock, #{}, Pid1, Pid2, #{step_handler => SleepyF})
+        cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => SleepyF})
     end),
     receive_message(join_start),
     %% We actually would not return from cets_join:join unless we get the lock
     spawn_link(fun() ->
-        ok = cets_join:join(Lock, #{}, Pid1, Pid2, #{step_handler => F})
+        ok = cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => F})
     end),
     receive_message(before_retry).
 

--- a/test/cets_test_wait.erl
+++ b/test/cets_test_wait.erl
@@ -1,0 +1,74 @@
+-module(cets_test_wait).
+-export([wait_until/2]).
+
+%% From mongoose_helper
+
+%% @doc Waits `TimeLeft` for `Fun` to return `ExpectedValue`
+%% If the result of `Fun` matches `ExpectedValue`, returns {ok, ExpectedValue}
+%% If no value is returned or the result doesn't match `ExpectedValue`, returns one of the following:
+%% {Name, History}, if Opts as #{name => Name} is passed
+%% {timeout, History}, otherwise
+
+wait_until(Fun, ExpectedValue) ->
+    wait_until(Fun, ExpectedValue, #{}).
+
+%% Example: wait_until(fun () -> ... end, SomeVal, #{time_left => timer:seconds(2)})
+wait_until(Fun, ExpectedValue, Opts) ->
+    Defaults = #{
+        validator => fun(NewValue) -> ExpectedValue =:= NewValue end,
+        expected_value => ExpectedValue,
+        time_left => timer:seconds(5),
+        sleep_time => 100,
+        history => [],
+        name => timeout
+    },
+    do_wait_until(Fun, maps:merge(Defaults, Opts)).
+
+do_wait_until(
+    _Fun,
+    #{
+        expected_value := ExpectedValue,
+        time_left := TimeLeft,
+        history := History,
+        name := Name
+    } = Opts
+) when TimeLeft =< 0 ->
+    error({Name, ExpectedValue, simplify_history(lists:reverse(History), 1), on_error(Opts)});
+do_wait_until(Fun, #{validator := Validator} = Opts) ->
+    try Fun() of
+        Value ->
+            case Validator(Value) of
+                true -> {ok, Value};
+                _ -> wait_and_continue(Fun, Value, Opts)
+            end
+    catch
+        Error:Reason:Stacktrace ->
+            wait_and_continue(Fun, {Error, Reason, Stacktrace}, Opts)
+    end.
+
+on_error(#{on_error := F}) ->
+    F();
+on_error(_Opts) ->
+    ok.
+
+simplify_history([H | [H | _] = T], Times) ->
+    simplify_history(T, Times + 1);
+simplify_history([H | T], Times) ->
+    [{times, Times, H} | simplify_history(T, 1)];
+simplify_history([], 1) ->
+    [].
+
+wait_and_continue(
+    Fun,
+    FunResult,
+    #{
+        time_left := TimeLeft,
+        sleep_time := SleepTime,
+        history := History
+    } = Opts
+) ->
+    timer:sleep(SleepTime),
+    do_wait_until(Fun, Opts#{
+        time_left => TimeLeft - SleepTime,
+        history => [FunResult | History]
+    }).


### PR DESCRIPTION
This issue addresses MIM-1968.

The changes include:
- Tests for cets_join
- Step function to write tests for joining procedure
- Fixes for the logic - we do more validation before applying the changes
- We set join_ref when we join - all nodes should have the same join_ref after joining.
- We actually check join_ref before sending messages, check check_server in cets module.
- We don't catch errors for long calls anymore - it confuses result types. It also leads to nested `{error, {error, _}_}` when there is long call inside of a long operation 
- There is an issue in cover code reports, so we have to make a map outside of `LOG_ERROR` call and pass it into it. I don't think there would be any performance issues (unless someone disables all log messages), but still we could fix it once OTP fixes cover tool. For now I prefer good cover reports - they actually allow to find errors in logic https://github.com/erlang/otp/issues/7531  