### PR TITLE
Use cets_ack process to collect replies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {dialyzer, [
     {warnings, [
+        unknown,
         no_return,
         no_unused,
         no_improper_lists,

--- a/rebar.config
+++ b/rebar.config
@@ -1,16 +1,6 @@
 {dialyzer, [
     {warnings, [
         unknown,
-        no_return,
-        no_unused,
-        no_improper_lists,
-        no_fun_app,
-        no_match,
-        no_opaque,
-        no_fail_call,
-        no_contracts,
-        no_behaviours,
-        no_undefined_callbacks,
         unmatched_returns,
         error_handling,
         underspecs

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -482,16 +482,12 @@ set_other_servers(Servers, State = #{tab := Tab, ack_pid := AckPid}) ->
 pids_to_nodes(Pids) ->
     lists:map(fun node/1, Pids).
 
-ets_delete_keys(Tab, [Key | Keys]) ->
-    ets:delete(Tab, Key),
-    ets_delete_keys(Tab, Keys);
-ets_delete_keys(_Tab, []) ->
+ets_delete_keys(Tab, Keys) ->
+    [ets:delete(Tab, Key) || Key <- Keys],
     ok.
 
-ets_delete_objects(Tab, [Object | Objects]) ->
-    ets:delete_object(Tab, Object),
-    ets_delete_objects(Tab, Objects);
-ets_delete_objects(_Tab, []) ->
+ets_delete_objects(Tab, Objects) ->
+    [ets:delete_object(Tab, Object) || Object <- Objects],
     ok.
 
 %% Handle operation from a remote node

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -271,12 +271,9 @@ delete_many_request(Server, Keys) ->
 delete_objects_request(Server, Objects) ->
     cets_call:async_operation(Server, {delete_objects, Objects}).
 
--spec wait_response(request_id(), non_neg_integer() | infinity) -> ok.
+-spec wait_response(request_id(), non_neg_integer() | infinity) -> {reply, ok} | {error, term()}.
 wait_response(Mon, Timeout) ->
-    case gen_server:wait_response(Mon, Timeout) of
-        {reply, ok} -> ok;
-        Other -> error(Other)
-    end.
+    gen_server:wait_response(Mon, Timeout).
 
 %% Get a list of other CETS processes that are handling this table.
 -spec other_servers(server_ref()) -> [server_ref()].

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -553,7 +553,7 @@ replicate(Op, From, #{ack_pid := AckPid, other_servers := Servers}) ->
     cets_ack:add(AckPid, From),
     RemoteOp = {remote_op, Op, From, AckPid},
     [send_remote_op(Server, RemoteOp) || Server <- Servers],
-    %% AckPid would call gen_server:reply(From, ok) ones all the remote servers reply
+    %% AckPid would call gen_server:reply(From, ok) once all the remote servers reply
     ok.
 
 -spec send_remote_op(server_pid(), remote_op()) -> noconnect | ok.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -568,23 +568,22 @@ apply_backlog(State = #{backlog := Backlog}) ->
 handle_unpause(Mon, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
         true ->
-            handle_unpause2(Mon, Mons, State);
+            {reply, ok, handle_unpause2(Mon, Mons, State)};
         false ->
             {reply, {error, unknown_pause_monitor}, State}
     end.
 
+-spec handle_unpause2(reference(), [reference()], state()) -> state().
 handle_unpause2(Mon, Mons, State) ->
     erlang:demonitor(Mon, [flush]),
     Mons2 = lists:delete(Mon, Mons),
     State2 = State#{pause_monitors := Mons2},
-    State3 =
-        case Mons2 of
-            [] ->
-                apply_backlog(State2);
-            _ ->
-                State2
-        end,
-    {reply, ok, State3}.
+    case Mons2 of
+        [] ->
+            apply_backlog(State2);
+        _ ->
+            State2
+    end.
 
 -spec handle_get_info(state()) -> info().
 handle_get_info(

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -140,7 +140,7 @@
 
 -type handle_down_fun() :: fun((#{remote_pid := pid(), table := table_name()}) -> ok).
 -type handle_conflict_fun() :: fun((tuple(), tuple()) -> tuple()).
--type handle_wrong_leader() :: fun((term()) -> ok).
+-type handle_wrong_leader() :: fun((#{from := from(), op := op(), server := pid()}) -> ok).
 -type start_opts() :: #{
     type => ordered_set | bag,
     keypos => non_neg_integer(),
@@ -150,12 +150,6 @@
 }.
 
 -export_type([request_id/0, op/0, server_ref/0, long_msg/0, info/0, table_name/0]).
-
--type local_mon_tab() :: atom().
--type remote_mon_tab() :: {remote, node(), local_mon_tab()}.
--type local_or_remote_mon_tab() :: local_mon_tab() | remote_mon_tab().
--type wait_info() :: {Servers :: [pid()], MonTabInfo :: local_or_remote_mon_tab()}.
--export_type([wait_info/0, local_or_remote_mon_tab/0]).
 
 %% API functions
 

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -338,7 +338,7 @@ init({Tab, Opts}) ->
     _ = ets:new(MonTab, [public, named_table]),
     cets_metadata:init(Tab),
     cets_metadata:set(Tab, leader, self()),
-    {ok, MonPid} = cets_mon_cleaner:start_link(MonTab, MonTab),
+    {ok, MonPid} = cets_ack:start_link(MonTab, MonTab),
     {ok, #{
         tab => Tab,
         mon_tab => MonTab,

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -339,8 +339,7 @@ init({Tab, Opts}) ->
     _ = ets:new(Tab, [Type, named_table, public, {keypos, KeyPos}]),
     cets_metadata:init(Tab),
     cets_metadata:set(Tab, leader, self()),
-    AckName = list_to_atom(atom_to_list(Tab) ++ "_ack"),
-    {ok, AckPid} = cets_ack:start_link(AckName),
+    {ok, AckPid} = cets_ack:start_link(Tab),
     {ok, #{
         tab => Tab,
         ack_pid => AckPid,

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -22,20 +22,21 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-type from() :: from().
 -type state() :: #{
-    gen_server:from() => [pid()]
+    from() => [pid()]
 }.
 
 start_link(Name) ->
     gen_server:start_link({local, Name}, ?MODULE, [], []).
 
--spec add(pid(), gen_server:from(), [pid()]) -> ok.
+-spec add(pid(), from(), [pid()]) -> ok.
 add(AckPid, From, Servers) ->
     AckPid ! {add, From, Servers},
     ok.
 
 %% Called by a remote server after an operation is applied.
--spec ack(pid(), gen_server:from(), pid()) -> ok.
+-spec ack(pid(), from(), pid()) -> ok.
 ack(AckPid, From, RemotePid) ->
     %% nosuspend makes message sending unreliable
     erlang:send(AckPid, {ack, From, RemotePid}, [noconnect]),
@@ -86,7 +87,7 @@ handle_remote_down(RemotePid, State) ->
     end,
     maps:fold(F, State, State).
 
--spec handle_updated(gen_server:from(), pid(), state()) -> state().
+-spec handle_updated(from(), pid(), state()) -> state().
 handle_updated(From, RemotePid, State) ->
     case State of
         #{From := Servers} ->
@@ -96,7 +97,7 @@ handle_updated(From, RemotePid, State) ->
             State
     end.
 
--spec handle_updated(gen_server:from(), pid(), [pid(), ...], state()) -> state().
+-spec handle_updated(from(), pid(), [pid(), ...], state()) -> state().
 handle_updated(From, RemotePid, Servers, State) ->
     %% Removes the remote server from a waiting list
     case lists:delete(RemotePid, Servers) of

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -3,7 +3,7 @@
 %% Unless the caller process crashes.
 %% This server removes such entries from the MonTab.
 %% We don't expect the MonTab to be extremely big, so this check should be quick.
--module(cets_mon_cleaner).
+-module(cets_ack).
 -behaviour(gen_server).
 
 -export([start_link/2]).

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -60,8 +60,8 @@ send_remote_down(AckPid, RemotePid) ->
 
 -spec init(atom()) -> {ok, state()}.
 init(_) ->
-    State = #{},
-    {ok, State}.
+    %% We store pending query registrations directly in the state map
+    {ok, #{}}.
 
 -spec handle_call(term(), _From, state()) -> {reply, state()}.
 handle_call(Msg, From, State) ->

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -109,7 +109,9 @@ code_change(_OldVsn, State, _Extra) ->
 %% Calling add when the server list is empty is not allowed
 %% (and CETS process checks for it when sending us a new task)
 handle_add(From, State = #{servers := [_ | _] = Servers}) ->
-    maps:put(From, Servers, State).
+    maps:put(From, Servers, State);
+handle_add(_, _) ->
+    error(unexpected_add_msg).
 
 -spec handle_remote_down(server_pid(), state()) -> state().
 handle_remote_down(RemotePid, State) ->
@@ -138,8 +140,8 @@ handle_updated(From, RemotePid, Servers, State) ->
     %% Removes the remote server from a waiting list
     case lists:delete(RemotePid, Servers) of
         [] ->
-            %% Send reply to our client
-            %% confirming that the operation has finished
+            %% Send a reply to our client
+            %% confirming that his operation has been finished
             gen_server:reply(From, ok),
             %% Remove the task
             maps:remove(From, State);

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -2,7 +2,7 @@
 %%
 %% Contains a list of processes, that are waiting for writes to finish.
 %% Collects acks from nodes in the cluster.
-%% When one of the remote nodes go down, the server stops waiting for acks from it.
+%% When one of the remote nodes goes down, the server stops waiting for acks from it.
 -module(cets_ack).
 -behaviour(gen_server).
 
@@ -51,7 +51,7 @@ set_servers(AckPid, Servers) ->
     gen_server:cast(AckPid, {set_servers, Servers}),
     ok.
 
-%% Adds a new task to wait replies
+%% Adds a new task to wait for replies
 -spec add(ack_pid(), from()) -> ok.
 add(AckPid, From) ->
     AckPid ! {add, From},
@@ -60,7 +60,7 @@ add(AckPid, From) ->
 %% Called by a remote server after an operation is applied.
 -spec ack(ack_pid(), from(), server_pid()) -> ok.
 ack(AckPid, From, RemotePid) ->
-    %% nosuspend makes message sending unreliable
+    %% nosuspend is not used, because it would make message sending unreliable
     erlang:send(AckPid, {ack, From, RemotePid}, [noconnect]),
     ok.
 

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -28,7 +28,7 @@
 
 -type from() :: gen_server:from().
 -type state() :: #{
-    from() => [pid()]
+    from() => [pid(), ...]
 }.
 
 %% API functions

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -1,8 +1,6 @@
-%% Monitor Table contains processes, that are waiting for writes to finish.
-%% It is usually cleaned automatically.
-%% Unless the caller process crashes.
-%% This server removes such entries from the MonTab.
-%% We don't expect the MonTab to be extremely big, so this check should be quick.
+%% Contains a list of processes, that are waiting for writes to finish.
+%% Collects acks from nodes in the cluster.
+%% When one of the remote nodes go down, the server stops waiting for acks from it.
 -module(cets_ack).
 -behaviour(gen_server).
 

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -76,7 +76,7 @@ send_remote_down(AckPid, RemotePid) ->
 init(_) ->
     {ok, #{servers => []}}.
 
--spec handle_call(term(), _From, state()) -> {reply, state()}.
+-spec handle_call(term(), _From, state()) -> {reply, {error, unexpected_call}, state()}.
 handle_call(Msg, From, State) ->
     ?LOG_ERROR(#{what => unexpected_call, msg => Msg, from => From}),
     {reply, {error, unexpected_call}, State}.

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -67,8 +67,14 @@ send_leader_op(Server, Op, Backoff) ->
     Leader = cets:get_leader(Server),
     Res = sync_operation(Leader, {leader_op, Op}),
     case Res of
-        {error, wrong_leader} ->
-            ?LOG_WARNING(#{what => wrong_leader, server => Server, operation => Op}),
+        {error, {wrong_leader, ExpectedLeader}} ->
+            ?LOG_WARNING(#{
+                what => wrong_leader,
+                server => Server,
+                operation => Op,
+                called_leader => Leader,
+                expected_leader => ExpectedLeader
+            }),
             %% This could happen if a new node joins the cluster.
             %% So, a simple retry should help.
             case Backoff of

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -27,11 +27,7 @@ long_call(Server, Msg) ->
 long_call(Server, Msg, Info) ->
     case where(Server) of
         Pid when is_pid(Pid) ->
-            Info2 = Info#{
-                server => Server,
-                pid => Pid,
-                node => node(Pid)
-            },
+            Info2 = Info#{server => Server, pid => Pid, node => node(Pid)},
             F = fun() -> gen_server:call(Pid, Msg, infinity) end,
             cets_long:run_safely(Info2, F);
         undefined ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -28,9 +28,9 @@ long_call(Server, Msg, Info) ->
     case where(Server) of
         Pid when is_pid(Pid) ->
             Info2 = Info#{
-                remote_server => Server,
-                remote_pid => Pid,
-                remote_node => node(Pid)
+                server => Server,
+                pid => Pid,
+                node => node(Pid)
             },
             F = fun() -> gen_server:call(Pid, Msg, infinity) end,
             cets_long:run_safely(Info2, F);
@@ -42,12 +42,12 @@ long_call(Server, Msg, Info) ->
 %% Returns immediately.
 %% You can wait for response from all nodes by calling wait_response/2.
 -spec async_operation(server_ref(), op()) -> request_id().
-async_operation(Server, Msg) ->
-    gen_server:send_request(Server, {op, Msg}).
+async_operation(Server, Op) ->
+    gen_server:send_request(Server, {op, Op}).
 
 -spec sync_operation(server_ref(), op()) -> sync_operation_return().
-sync_operation(Server, Msg) ->
-    gen_server:call(Server, {op, Msg}, infinity).
+sync_operation(Server, Op) ->
+    gen_server:call(Server, {op, Op}, infinity).
 
 -spec where(server_ref()) -> pid() | undefined.
 where(Pid) when is_pid(Pid) -> Pid;

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -61,7 +61,7 @@ start_common(F, Opts) ->
 add_table(Server, Table) ->
     gen_server:call(Server, {add_table, Table}).
 
--spec get_tables(server()) -> [cets:table_name()].
+-spec get_tables(server()) -> {ok, [cets:table_name()]}.
 get_tables(Server) ->
     gen_server:call(Server, get_tables).
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -469,7 +469,7 @@ events_are_applied_in_the_correct_order_after_unpause(_Config) ->
     R4 = cets:delete_many_request(T, [5, 4]),
     [] = lists:sort(cets:dump(T)),
     ok = cets:unpause(Pid, PauseMon),
-    [ok = cets:wait_response(R, 5000) || R <- [R1, R2, R3, R4]],
+    [{reply, ok} = cets:wait_response(R, 5000) || R <- [R1, R2, R3, R4]],
     [{2}, {3}, {6}, {7}] = lists:sort(cets:dump(T)).
 
 pause_multiple_times(_Config) ->
@@ -487,8 +487,8 @@ pause_multiple_times(_Config) ->
     [] = cets:dump(T),
     ok = cets:unpause(Pid, PauseMon2),
     pong = cets:ping(Pid),
-    cets:wait_response(Ref1, 5000),
-    cets:wait_response(Ref2, 5000),
+    {reply, ok} = cets:wait_response(Ref1, 5000),
+    {reply, ok} = cets:wait_response(Ref2, 5000),
     [{1}, {2}] = lists:sort(cets:dump(T)).
 
 unpause_twice(_Config) ->
@@ -505,7 +505,7 @@ write_returns_if_remote_server_crashes(_Config) ->
     sys:suspend(Pid2),
     R = cets:insert_request(c1, {1}),
     exit(Pid2, oops),
-    ok = cets:wait_response(R, 5000).
+    {reply, ok} = cets:wait_response(R, 5000).
 
 ack_process_stops_correctly(_Config) ->
     {ok, Pid} = cets:start(ack_stops, #{}),
@@ -534,7 +534,7 @@ ack_process_handles_unknown_remote_server(_Config) ->
     cets_ack:ack(AckPid, From, RandomPid),
     sys:resume(Pid2),
     %% Ack process still works fine
-    ok = cets:wait_response(R, 5000).
+    {reply, ok} = cets:wait_response(R, 5000).
 
 ack_process_handles_unknown_from(_Config) ->
     {ok, Pid1} = cets:start(ack_unkn_from1, #{}),
@@ -545,7 +545,7 @@ ack_process_handles_unknown_from(_Config) ->
     From = {self(), make_ref()},
     cets_ack:ack(AckPid, From, self()),
     %% Ack process still works fine
-    ok = cets:wait_response(R, 5000).
+    {reply, ok} = cets:wait_response(R, 5000).
 
 sync_using_name_works(_Config) ->
     {ok, _Pid1} = cets:start(c4, #{}),
@@ -554,7 +554,7 @@ sync_using_name_works(_Config) ->
 insert_many_request(_Config) ->
     {ok, Pid} = cets:start(c5, #{}),
     R = cets:insert_many_request(Pid, [{a}, {b}]),
-    ok = cets:wait_response(R, 5000),
+    {reply, ok} = cets:wait_response(R, 5000),
     [{a}, {b}] = ets:tab2list(c5).
 
 insert_into_bag(_Config) ->
@@ -584,7 +584,7 @@ delete_request_from_bag(_Config) ->
     {ok, _Pid} = cets:start(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}]),
     R = cets:delete_object_request(T, {1, 2}),
-    ok = cets:wait_response(R, 5000),
+    {reply, ok} = cets:wait_response(R, 5000),
     [{1, 1}] = cets:dump(T).
 
 delete_request_many_from_bag(_Config) ->
@@ -592,7 +592,7 @@ delete_request_many_from_bag(_Config) ->
     {ok, _Pid} = cets:start(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}, {1, 3}]),
     R = cets:delete_objects_request(T, [{1, 1}, {1, 3}]),
-    ok = cets:wait_response(R, 5000),
+    {reply, ok} = cets:wait_response(R, 5000),
     [{1, 2}] = cets:dump(T).
 
 insert_into_bag_is_replicated(_Config) ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -530,7 +530,7 @@ ack_process_handles_unknown_remote_server(_Config) ->
     R = cets:insert_request(Pid1, {1}),
     pong = cets:ping(Pid1),
     %% Extract From value
-    [{From, [Pid2]}] = maps:to_list(sys:get_state(AckPid)),
+    [{servers, _}, {From, [Pid2]}] = maps:to_list(sys:get_state(AckPid)),
     cets_ack:ack(AckPid, From, RandomPid),
     sys:resume(Pid2),
     %% Ack process still works fine

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -538,11 +538,11 @@ mon_cleaner_works(_Config) ->
 
 mon_cleaner_stops_correctly(_Config) ->
     {ok, Pid} = cets:start(cleaner_stops, #{}),
-    #{mon_pid := MonPid} = cets:info(Pid),
-    MonMon = monitor(process, MonPid),
+    #{ack_pid := AckPid} = cets:info(Pid),
+    MonMon = monitor(process, AckPid),
     cets:stop(Pid),
     receive
-        {'DOWN', MonMon, process, MonPid, normal} -> ok
+        {'DOWN', MonMon, process, AckPid, normal} -> ok
     after 5000 -> ct:fail(timeout)
     end.
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -50,6 +50,7 @@ all() ->
         delete_request_many_from_bag,
         insert_into_bag_is_replicated,
         insert_into_keypos_table,
+        table_name_works,
         info_contains_opts
     ].
 
@@ -626,6 +627,13 @@ insert_into_keypos_table(_Config) ->
     cets:insert(T, {rec, 2}),
     [{rec, 1}] = lists:sort(ets:lookup(T, 1)),
     [{rec, 1}, {rec, 2}] = lists:sort(cets:dump(T)).
+
+table_name_works(_Config) ->
+    T = tabnamecheck,
+    {ok, Pid} = cets:start(T, #{}),
+    {ok, T} = cets:table_name(T),
+    {ok, T} = cets:table_name(Pid),
+    #{table := T} = cets:info(Pid).
 
 info_contains_opts(_Config) ->
     {ok, Pid} = cets:start(info_contains_opts, #{type => bag}),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -52,11 +52,12 @@ all() ->
         insert_into_keypos_table,
         table_name_works,
         info_contains_opts,
-        unknown_down_messageis_ignored,
-        unknown_messageis_ignored,
-        unknown_cast_messageis_ignored,
-        unknown_messageis_ignored_in_ack_process,
-        unknown_cast_messageis_ignored_in_ack_process
+        unknown_down_message_is_ignored,
+        unknown_message_is_ignored,
+        unknown_cast_message_is_ignored,
+        unknown_message_is_ignored_in_ack_process,
+        unknown_cast_message_is_ignored_in_ack_process,
+        unknown_call_returns_error_from_ack_process
     ].
 
 init_per_suite(Config) ->
@@ -644,32 +645,38 @@ info_contains_opts(_Config) ->
     {ok, Pid} = cets:start(info_contains_opts, #{type => bag}),
     #{opts := #{type := bag}} = cets:info(Pid).
 
-unknown_down_messageis_ignored(_Config) ->
+unknown_down_message_is_ignored(_Config) ->
     {ok, Pid} = cets:start(rand_down_msg, #{}),
     RandPid = spawn(fun() -> ok end),
     Pid ! {'DOWN', make_ref(), process, RandPid, oops},
     still_works(Pid).
 
-unknown_messageis_ignored(_Config) ->
+unknown_message_is_ignored(_Config) ->
     {ok, Pid} = cets:start(unkn_msg, #{}),
     Pid ! oops,
     still_works(Pid).
 
-unknown_cast_messageis_ignored(_Config) ->
+unknown_cast_message_is_ignored(_Config) ->
     {ok, Pid} = cets:start(unkn_cast_msg, #{}),
     gen_server:cast(Pid, oops),
     still_works(Pid).
 
-unknown_messageis_ignored_in_ack_process(_Config) ->
+unknown_message_is_ignored_in_ack_process(_Config) ->
     {ok, Pid} = cets:start(ack_unkn_msg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     AckPid ! oops,
     still_works(Pid).
 
-unknown_cast_messageis_ignored_in_ack_process(_Config) ->
+unknown_cast_message_is_ignored_in_ack_process(_Config) ->
     {ok, Pid} = cets:start(ack_unkn_cast_msg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     gen_server:cast(AckPid, oops),
+    still_works(Pid).
+
+unknown_call_returns_error_from_ack_process(_Config) ->
+    {ok, Pid} = cets:start(ack_unkn_call_msg, #{}),
+    #{ack_pid := AckPid} = cets:info(Pid),
+    {error, unexpected_call} = gen_server:call(AckPid, oops),
     still_works(Pid).
 
 still_works(Pid) ->


### PR DESCRIPTION
Addresses: MIM-1969

After adding leader_ops (i.e. insert_new), the logic in cets_call becomes a bit complicated.

Redesign inclides:
- use gen_server:call API instead of cets_call module.
- use a separate process to collect responses from nodes in cluster: cets_ack.
- use gen_server:reply once all replies collected (or the remote nodes crashed).

Motivation: 
- less code, less logic inside of the caller client process (i.e. it would only wait for a single gen_server reply now). 
- mon_tab ETS table could be removed, so no need for RPC calls to remove from it.

Initial benchmarking shows that the solution is pretty performant.