### PR TITLE
Use makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run tests
-      run: rebar3 as test ct --sname=ct1 --cover
-    - name: Send test coverage report
-      run: rebar3 as test codecov analyze
+      run: make cover_test
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:
@@ -37,10 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run dialyzer
-      run: rebar3 dialyzer
+      run: make dial
 
   gradualizer:
     runs-on: ubuntu-latest
@@ -50,10 +44,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run gradualizer
-      run: rebar3 as grad gradualizer
+      run: make grad
 
   xref:
     runs-on: ubuntu-latest
@@ -63,10 +55,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run xref
-      run: rebar3 xref
+      run: make xref
 
   erlfmt:
     runs-on: ubuntu-latest
@@ -77,4 +67,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run erlfmt
-      run: rebar3 fmt --check
+      run: make check_format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
     - name: Run dialyzer
       run: rebar3 dialyzer
 
+  gradualizer:
+    runs-on: ubuntu-latest
+
+    container:
+      image: erlang:25
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Compile
+      run: rebar3 compile
+    - name: Run gradualizer
+      run: rebar3 as grad gradualizer
+
   xref:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Get deps and compile
+      run: make pre_test
     - name: Run tests
       run: make cover_test
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       run: make pre_test
     - name: Run tests
       run: make cover_test
+    - name: Produce codecov.json report
+      run: make cover_json
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build/
 *.sw*
 codecov.json
 rebar3.crashdump
+*.beam

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _build/
 # vim temporary files
 *.sw*
+codecov.json
+rebar3.crashdump

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ dial:
 grad:
 	rebar3 as grad gradualizer
 
+# Separate task to make output on CI more pretty
+pre_test:
+	rebar3 as test compile
+
 cover_test:
 	rebar3 as test ct --sname=ct1 --cover
 	rebar3 as test codecov analyze

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Run all precommit checks
+all: format run_test xref dial grad
+
+format:
+	rebar3 as format fmt -w
+
+check_format:
+	rebar3 as format fmt --check
+
+xref:
+	rebar3 xref
+
+dial:
+	rebar3 dialyzer
+
+grad:
+	rebar3 as grad gradualizer
+
+cover_test:
+	rebar3 as test ct --sname=ct1 --cover
+	rebar3 as test codecov analyze
+
+run_test:
+	rebar3 as test ct --sname=ct1

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,12 @@ grad:
 pre_test:
 	rebar3 as test compile
 
-cover_test:
-	rebar3 as test ct --sname=ct1 --cover
-	rebar3 as test codecov analyze
-
 run_test:
 	rebar3 as test ct --sname=ct1
+
+cover_test:
+	rebar3 as test ct --sname=ct1 --cover
+
+# Produce codecov.json report
+cover_json:
+	rebar3 as test codecov analyze

--- a/rebar.config
+++ b/rebar.config
@@ -8,13 +8,18 @@
     ]}
 ]}.
 
-%% Enables "rebar3 fmt" command
-{project_plugins, [erlfmt]}.
-
 {profiles, [
     {test, [
         {plugins, [
             {rebar3_codecov, "0.4.0"}
+        ]},
+        %% Include test suites into the cover report
+        %% so we would know about not-called testcases
+        {src_dirs, ["src", "test"]}
+    ]},
+    {format, [
+        {plugins, [
+            erlfmt
         ]}
     ]},
     {grad, [

--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,10 @@
         {plugins, [
             {rebar3_codecov, "0.4.0"}
         ]}
+    ]},
+    {grad, [
+        {plugins, [
+            {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {branch, "master"}}}
+        ]}
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {profiles, [
     {test, [
         {plugins, [
-            {rebar3_codecov, "0.4.0"}
+            {rebar3_codecov, "0.5.0"}
         ]},
         %% Include test suites into the cover report
         %% so we would know about not-called testcases

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-rebar3 ct --sname=ct1

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -87,10 +87,7 @@
 -type server_pid() :: pid().
 -type server_ref() ::
     server_pid()
-    | atom()
-    | {local, atom()}
-    | {global, term()}
-    | {via, module(), term()}.
+    | atom().
 -type request_id() :: gen_server:request_id().
 -type from() :: gen_server:from().
 -type join_ref() :: cets_join:join_ref().
@@ -667,17 +664,18 @@ handle_get_info(
     #{
         table => Tab,
         nodes => lists:usort(pids_to_nodes([self() | Servers])),
-        size => returns_non_neg_integer(ets:info(Tab, size)),
-        memory => returns_non_neg_integer(ets:info(Tab, memory)),
+        size => assert_type_non_neg_integer(ets:info(Tab, size)),
+        memory => assert_type_non_neg_integer(ets:info(Tab, memory)),
         ack_pid => AckPid,
         join_ref => JoinRef,
         opts => Opts
     }.
 
-%% We are sure that the ETS table exists when running handle_get_info
-%% But gradualizer does not know that, so let us tell it with the spec
--spec returns_non_neg_integer(any()) -> non_neg_integer().
-returns_non_neg_integer(X) -> X.
+%% Assert for gradualizer
+%% ets:info would not return undefined in handle_get_info, because the table exists.
+-compile({inline, [assert_type_non_neg_integer/1]}).
+-spec assert_type_non_neg_integer(any()) -> non_neg_integer().
+assert_type_non_neg_integer(X) -> X.
 
 %% Cleanup
 -spec call_user_handle_down(server_pid(), state()) -> ok.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -667,14 +667,17 @@ handle_get_info(
     #{
         table => Tab,
         nodes => lists:usort(pids_to_nodes([self() | Servers])),
-        size => assert_integer(ets:info(Tab, size)),
-        memory => assert_integer(ets:info(Tab, memory)),
+        size => returns_non_neg_integer(ets:info(Tab, size)),
+        memory => returns_non_neg_integer(ets:info(Tab, memory)),
         ack_pid => AckPid,
         join_ref => JoinRef,
         opts => Opts
     }.
 
-assert_integer(X) when is_integer(X) -> X.
+%% We are sure that the ETS table exists when running handle_get_info
+%% But gradualizer does not know that, so let us tell it with the spec
+-spec returns_non_neg_integer(any()) -> non_neg_integer().
+returns_non_neg_integer(X) -> X.
 
 %% Cleanup
 -spec call_user_handle_down(server_pid(), state()) -> ok.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -175,7 +175,7 @@
 %%   We recommend to define that function if keys could have conflicts.
 %%   This function would be called once for each conflicting key.
 %%   We recommend to keep that function pure (or at least no blocking calls from it).
--spec start(table_name(), start_opts()) -> {ok, server_pid()}.
+-spec start(table_name(), start_opts()) -> gen_server:start_ret().
 start(Tab, Opts) when is_atom(Tab) ->
     case check_opts(Opts) of
         [] ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -281,7 +281,16 @@ wait_response(Mon, Timeout) ->
 -spec get_leader(server_ref()) -> server_pid().
 get_leader(Tab) when is_atom(Tab) ->
     %% Optimization: replace call with ETS lookup
-    cets_metadata:get(Tab, leader);
+    try
+        cets_metadata:get(Tab, leader)
+    catch
+        error:badarg ->
+            %% Failed to get from metadata,
+            %% Retry by calling the server process.
+            %% Most likely would fail too, but we want the same error format
+            %% when calling get_leader using either atom() or pid()
+            gen_server:call(Tab, get_leader)
+    end;
 get_leader(Server) ->
     gen_server:call(Server, get_leader).
 

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -155,6 +155,8 @@
     handle_conflict => handle_conflict_fun(),
     handle_wrong_leader => handle_wrong_leader()
 }.
+-type response_return() ::
+    timeout | {error, term()} | {reply, term()}.
 
 -export_type([request_id/0, op/0, server_pid/0, server_ref/0, long_msg/0, info/0, table_name/0]).
 
@@ -272,8 +274,6 @@ delete_many_request(Server, Keys) ->
 delete_objects_request(Server, Objects) ->
     cets_call:async_operation(Server, {delete_objects, Objects}).
 
--type response_return() ::
-    timeout | {error, term()} | {reply, term()}.
 -spec wait_response(request_id(), timeout()) -> response_return().
 wait_response(Mon, Timeout) ->
     gen_server:wait_response(Mon, Timeout).
@@ -708,8 +708,7 @@ handle_wrong_leader(Op, From, #{opts := #{handle_wrong_leader := F}}) ->
 handle_wrong_leader(_Op, _From, _State) ->
     ok.
 
--type start_error() :: bag_with_conflict_handler.
--spec check_opts(start_opts()) -> [start_error()].
+-spec check_opts(start_opts()) -> [bag_with_conflict_handler].
 check_opts(#{handle_conflict := _, type := bag}) ->
     [bag_with_conflict_handler];
 check_opts(_) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -87,7 +87,10 @@
 -type server_pid() :: pid().
 -type server_ref() ::
     server_pid()
-    | atom().
+    | atom()
+    | {local, atom()}
+    | {global, term()}
+    | {via, module(), term()}.
 -type request_id() :: gen_server:request_id().
 -type from() :: gen_server:from().
 -type join_ref() :: cets_join:join_ref().

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -664,18 +664,18 @@ handle_get_info(
     #{
         table => Tab,
         nodes => lists:usort(pids_to_nodes([self() | Servers])),
-        size => assert_type_non_neg_integer(ets:info(Tab, size)),
-        memory => assert_type_non_neg_integer(ets:info(Tab, memory)),
+        size => non_neg_integer(ets:info(Tab, size)),
+        memory => non_neg_integer(ets:info(Tab, memory)),
         ack_pid => AckPid,
         join_ref => JoinRef,
         opts => Opts
     }.
 
-%% Assert for gradualizer
-%% ets:info would not return undefined in handle_get_info, because the table exists.
--compile({inline, [assert_type_non_neg_integer/1]}).
--spec assert_type_non_neg_integer(any()) -> non_neg_integer().
-assert_type_non_neg_integer(X) -> X.
+%% Tell gradualizer the correct type.
+%% ets:info/2 could not return undefined,
+%% because we know that the table is running.
+-spec non_neg_integer(any()) -> non_neg_integer().
+non_neg_integer(X) -> X.
 
 %% Cleanup
 -spec call_user_handle_down(server_pid(), state()) -> ok.

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -40,7 +40,7 @@
 
 %% API functions
 
--spec start_link(cets:table_name()) -> {ok, ack_pid()}.
+-spec start_link(cets:table_name()) -> gen_server:start_ret().
 start_link(Tab) ->
     Name = list_to_atom(atom_to_list(Tab) ++ "_ack"),
     gen_server:start_link({local, Name}, ?MODULE, [], []).

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -15,7 +15,7 @@
 -type op() :: cets:op().
 -type server_ref() :: cets:server_ref().
 -type long_msg() :: cets:long_msg().
--type sync_operation_return() :: ok | {error, Reason :: term()}.
+-type ok_or_error() :: ok | {error, Reason :: term()}.
 
 %% Does gen_server:call with better error reporting.
 %% It would log a warning if the call takes too long.
@@ -41,8 +41,14 @@ long_call(Server, Msg, Info) ->
 async_operation(Server, Op) ->
     gen_server:send_request(Server, {op, Op}).
 
--spec sync_operation(server_ref(), op()) -> sync_operation_return().
+-spec sync_operation(server_ref(), op()) -> ok.
 sync_operation(Server, Op) ->
+    ok = gen_server:call(Server, {op, Op}, infinity).
+
+%% Same as sync_operation, but could also return an error tuple
+%% (a separate version for gradualizer)
+-spec maybe_sync_operation(server_ref(), op()) -> ok_or_error().
+maybe_sync_operation(Server, Op) ->
     gen_server:call(Server, {op, Op}, infinity).
 
 -spec where(server_ref()) -> pid() | undefined.
@@ -63,13 +69,13 @@ backoff_intervals() ->
     [10, 50, 100, 500, 1000, 5000, 5000].
 
 %% Sends all requests to a single node in the cluster
--spec send_leader_op(server_ref(), op()) -> sync_operation_return().
+-spec send_leader_op(server_ref(), op()) -> ok_or_error().
 send_leader_op(Server, Op) ->
     send_leader_op(Server, Op, backoff_intervals()).
 
 send_leader_op(Server, Op, Backoff) ->
     Leader = cets:get_leader(Server),
-    Res = sync_operation(Leader, {leader_op, Op}),
+    Res = maybe_sync_operation(Leader, {leader_op, Op}),
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
             Log = #{

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -51,9 +51,13 @@ sync_operation(Server, Op) ->
 maybe_sync_operation(Server, Op) ->
     gen_server:call(Server, {op, Op}, infinity).
 
+%% From gen.erl
 -spec where(server_ref()) -> pid() | undefined | port().
 where(Pid) when is_pid(Pid) -> Pid;
-where(Name) when is_atom(Name) -> whereis(Name).
+where(Name) when is_atom(Name) -> whereis(Name);
+where({global, Name}) -> global:whereis_name(Name);
+where({local, Name}) -> whereis(Name);
+where({via, Module, Name}) -> Module:whereis_name(Name).
 
 %% Wait around 15 seconds before giving up
 %% (we don't count how much we spend calling the leader though)

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -47,10 +47,14 @@ sync_operation(Server, Op) ->
 
 -spec where(server_ref()) -> pid() | undefined.
 where(Pid) when is_pid(Pid) -> Pid;
-where(Name) when is_atom(Name) -> whereis(Name);
+where(Name) when is_atom(Name) -> pid_or_undefined(whereis(Name));
 where({global, Name}) -> global:whereis_name(Name);
-where({local, Name}) -> whereis(Name);
+where({local, Name}) -> pid_or_undefined(whereis(Name));
 where({via, Module, Name}) -> Module:whereis_name(Name).
+
+%% whereis/1 could return Port, so ignore Ports (makes Gradualizer happy)
+pid_or_undefined(undefined) -> undefined;
+pid_or_undefined(Pid) when is_pid(Pid) -> Pid.
 
 %% Wait around 15 seconds before giving up
 %% (we don't count how much we spend calling the leader though)

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -53,10 +53,7 @@ maybe_sync_operation(Server, Op) ->
 
 -spec where(server_ref()) -> pid() | undefined.
 where(Pid) when is_pid(Pid) -> Pid;
-where(Name) when is_atom(Name) -> pid_or_undefined(whereis(Name));
-where({global, Name}) -> global:whereis_name(Name);
-where({local, Name}) -> pid_or_undefined(whereis(Name));
-where({via, Module, Name}) -> Module:whereis_name(Name).
+where(Name) when is_atom(Name) -> pid_or_undefined(whereis(Name)).
 
 %% whereis/1 could return Port, so ignore Ports (makes Gradualizer happy)
 pid_or_undefined(undefined) -> undefined;

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -51,13 +51,9 @@ sync_operation(Server, Op) ->
 maybe_sync_operation(Server, Op) ->
     gen_server:call(Server, {op, Op}, infinity).
 
--spec where(server_ref()) -> pid() | undefined.
+-spec where(server_ref()) -> pid() | undefined | port().
 where(Pid) when is_pid(Pid) -> Pid;
-where(Name) when is_atom(Name) -> pid_or_undefined(whereis(Name)).
-
-%% whereis/1 could return Port, so ignore Ports (makes Gradualizer happy)
-pid_or_undefined(undefined) -> undefined;
-pid_or_undefined(Pid) when is_pid(Pid) -> Pid.
+where(Name) when is_atom(Name) -> whereis(Name).
 
 %% Wait around 15 seconds before giving up
 %% (we don't count how much we spend calling the leader though)

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -153,10 +153,9 @@ flush_all_checks() ->
     end.
 
 do_join(Tab, Node) ->
-    LocalPid = whereis(Tab),
     %% That would trigger autoconnect for the first time
-    case rpc:call(Node, erlang, whereis, [Tab]) of
-        Pid when is_pid(Pid), is_pid(LocalPid) ->
+    case {whereis(Tab), rpc:call(Node, erlang, whereis, [Tab])} of
+        {LocalPid, Pid} when is_pid(Pid), is_pid(LocalPid) ->
             Result = cets_join:join(cets_discovery, #{table => Tab}, LocalPid, Pid),
             #{what => join_result, result => Result, node => Node, table => Tab};
         Other ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -77,7 +77,7 @@ all() ->
         code_change_returns_ok,
         code_change_returns_ok_for_ack,
         run_spawn_forwards_errors,
-        long_call_to_unknown_name_returns_pid_not_found
+        long_call_to_unknown_name_throws_pid_not_found
     ].
 
 init_per_suite(Config) ->
@@ -985,8 +985,14 @@ run_spawn_forwards_errors(_Config) ->
                 matched
         end.
 
-long_call_to_unknown_name_returns_pid_not_found(_Config) ->
-    {error, pid_not_found} = cets_call:long_call(unknown_name_please, test).
+long_call_to_unknown_name_throws_pid_not_found(_Config) ->
+    matched =
+        try
+            cets_call:long_call(unknown_name_please, test)
+        catch
+            error:{pid_not_found, unknown_name_please} ->
+                matched
+        end.
 
 still_works(Pid) ->
     pong = cets:ping(Pid),


### PR DESCRIPTION
Changes:
- Use makefile for commands - we could run `rebar3 command` manually, but it is useful to have a command which runs all the checks.
- Put plugins into rebar3 profiles - faster CI (no need to compile fmt plugin when running gradualizer task).
- Enable cover for tests: we want to see if we have any dead code in tests, because if we add a case, but forget to add it into `all/0` list - it would never be called.
- Made a separate step for `pre_test` - we don't need it, but CI logs look better with it (we can ignore compilation output there).

WIP, merge gradualizer PR first.