### PR TITLE
Try emacs formatter

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,20 +1,19 @@
 {dialyzer, [
-    {warnings, [
-        unknown,
-        unmatched_returns,
-        error_handling,
-        underspecs
-        % overspecs, specdiffs
-    ]}
-]}.
+            {warnings, [
+                        unknown,
+                        unmatched_returns,
+                        error_handling,
+                        underspecs
+                                                % overspecs, specdiffs
+                       ]}
+           ]}.
 
-%% Enables "rebar3 fmt" command
-{project_plugins, [erlfmt]}.
+{project_plugins, [rebar3_fmt]}.
 
 {profiles, [
-    {test, [
-        {plugins, [
-            {rebar3_codecov, "0.4.0"}
-        ]}
-    ]}
-]}.
+            {test, [
+                    {plugins, [
+                               {rebar3_codecov, "0.4.0"}
+                              ]}
+                   ]}
+           ]}.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -18,143 +18,143 @@
 -behaviour(gen_server).
 
 -export([
-    start/2,
-    stop/1,
-    insert/2,
-    insert_many/2,
-    insert_new/2,
-    delete/2,
-    delete_many/2,
-    delete_object/2,
-    delete_objects/2,
-    dump/1,
-    remote_dump/1,
-    send_dump/4,
-    table_name/1,
-    other_nodes/1,
-    other_pids/1,
-    pause/1,
-    unpause/2,
-    get_leader/1,
-    set_leader/2,
-    sync/1,
-    ping/1,
-    info/1,
-    insert_request/2,
-    insert_many_request/2,
-    delete_request/2,
-    delete_many_request/2,
-    delete_object_request/2,
-    delete_objects_request/2,
-    wait_response/2,
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
-]).
+         start/2,
+         stop/1,
+         insert/2,
+         insert_many/2,
+         insert_new/2,
+         delete/2,
+         delete_many/2,
+         delete_object/2,
+         delete_objects/2,
+         dump/1,
+         remote_dump/1,
+         send_dump/4,
+         table_name/1,
+         other_nodes/1,
+         other_pids/1,
+         pause/1,
+         unpause/2,
+         get_leader/1,
+         set_leader/2,
+         sync/1,
+         ping/1,
+         info/1,
+         insert_request/2,
+         insert_many_request/2,
+         delete_request/2,
+         delete_many_request/2,
+         delete_object_request/2,
+         delete_objects_request/2,
+         wait_response/2,
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3
+        ]).
 
 -ignore_xref([
-    start/2,
-    stop/1,
-    insert/2,
-    insert_many/2,
-    insert_new/2,
-    delete/2,
-    delete_many/2,
-    delete_object/2,
-    delete_objects/2,
-    pause/1,
-    unpause/2,
-    get_leader/1,
-    set_leader/2,
-    sync/1,
-    ping/1,
-    info/1,
-    other_nodes/1,
-    insert_request/2,
-    insert_many_request/2,
-    delete_request/2,
-    delete_many_request/2,
-    delete_object_request/2,
-    delete_objects_request/2,
-    wait_response/2
-]).
+              start/2,
+              stop/1,
+              insert/2,
+              insert_many/2,
+              insert_new/2,
+              delete/2,
+              delete_many/2,
+              delete_object/2,
+              delete_objects/2,
+              pause/1,
+              unpause/2,
+              get_leader/1,
+              set_leader/2,
+              sync/1,
+              ping/1,
+              info/1,
+              other_nodes/1,
+              insert_request/2,
+              insert_many_request/2,
+              delete_request/2,
+              delete_many_request/2,
+              delete_object_request/2,
+              delete_objects_request/2,
+              wait_response/2
+             ]).
 
 -include_lib("kernel/include/logger.hrl").
 
 -type server_pid() :: pid().
 -type server_ref() ::
-    server_pid()
-    | atom()
-    | {local, atom()}
-    | {global, term()}
-    | {via, module(), term()}.
+        server_pid()
+      | atom()
+      | {local, atom()}
+      | {global, term()}
+      | {via, module(), term()}.
 -type request_id() :: gen_server:request_id().
 -type from() :: gen_server:from().
 -type join_ref() :: cets_join:join_ref().
 -type ack_pid() :: cets_ack:ack_pid().
 -type op() ::
-    {insert, tuple()}
-    | {delete, term()}
-    | {delete_object, term()}
-    | {insert_many, [tuple()]}
-    | {delete_many, [term()]}
-    | {delete_objects, [term()]}
-    | {insert_new, tuple()}
-    | {leader_op, op()}.
+        {insert, tuple()}
+      | {delete, term()}
+      | {delete_object, term()}
+      | {insert_many, [tuple()]}
+      | {delete_many, [term()]}
+      | {delete_objects, [term()]}
+      | {insert_new, tuple()}
+      | {leader_op, op()}.
 -type remote_op() ::
-    {remote_op, Op :: op(), From :: from(), AckPid :: ack_pid(), JoinRef :: join_ref()}.
+        {remote_op, Op :: op(), From :: from(), AckPid :: ack_pid(), JoinRef :: join_ref()}.
 -type backlog_entry() :: {op(), from()}.
 -type table_name() :: atom().
 -type pause_monitor() :: reference().
 -type state() :: #{
-    tab := table_name(),
-    ack_pid := ack_pid(),
-    join_ref := join_ref(),
-    %% Updated by set_other_servers/2 function only
-    other_servers := [server_pid()],
-    leader := server_pid(),
-    is_leader := boolean(),
-    opts := start_opts(),
-    backlog := [backlog_entry()],
-    pause_monitors := [pause_monitor()]
-}.
+                   tab := table_name(),
+                   ack_pid := ack_pid(),
+                   join_ref := join_ref(),
+                   %% Updated by set_other_servers/2 function only
+                   other_servers := [server_pid()],
+                   leader := server_pid(),
+                   is_leader := boolean(),
+                   opts := start_opts(),
+                   backlog := [backlog_entry()],
+                   pause_monitors := [pause_monitor()]
+                  }.
 
 -type long_msg() ::
-    pause
-    | ping
-    | remote_dump
-    | sync
-    | table_name
-    | get_info
-    | other_servers
-    | {unpause, reference()}
-    | get_leader
-    | {set_leader, boolean()}
-    | {send_dump, [server_pid()], join_ref(), [tuple()]}.
+        pause
+      | ping
+      | remote_dump
+      | sync
+      | table_name
+      | get_info
+      | other_servers
+      | {unpause, reference()}
+      | get_leader
+      | {set_leader, boolean()}
+      | {send_dump, [server_pid()], join_ref(), [tuple()]}.
 
 -type info() :: #{
-    table := table_name(),
-    nodes := [node()],
-    size := non_neg_integer(),
-    memory := non_neg_integer(),
-    ack_pid := ack_pid(),
-    join_ref := join_ref(),
-    opts := start_opts()
-}.
+                  table := table_name(),
+                  nodes := [node()],
+                  size := non_neg_integer(),
+                  memory := non_neg_integer(),
+                  ack_pid := ack_pid(),
+                  join_ref := join_ref(),
+                  opts := start_opts()
+                 }.
 
 -type handle_down_fun() :: fun((#{remote_pid := server_pid(), table := table_name()}) -> ok).
 -type handle_conflict_fun() :: fun((tuple(), tuple()) -> tuple()).
 -type handle_wrong_leader() :: fun((#{from := from(), op := op(), server := server_pid()}) -> ok).
 -type start_opts() :: #{
-    type => ordered_set | bag,
-    keypos => non_neg_integer(),
-    handle_down => handle_down_fun(),
-    handle_conflict => handle_conflict_fun(),
-    handle_wrong_leader => handle_wrong_leader()
-}.
+                        type => ordered_set | bag,
+                        keypos => non_neg_integer(),
+                        handle_down => handle_down_fun(),
+                        handle_conflict => handle_conflict_fun(),
+                        handle_wrong_leader => handle_wrong_leader()
+                       }.
 
 -export_type([request_id/0, op/0, server_pid/0, server_ref/0, long_msg/0, info/0, table_name/0]).
 
@@ -334,20 +334,20 @@ init({Tab, Opts}) ->
     cets_metadata:set(Tab, leader, self()),
     {ok, AckPid} = cets_ack:start_link(Tab),
     {ok, #{
-        tab => Tab,
-        ack_pid => AckPid,
-        other_servers => [],
-        %% Initial join_ref is random
-        join_ref => make_ref(),
-        leader => self(),
-        is_leader => true,
-        opts => Opts,
-        backlog => [],
-        pause_monitors => []
-    }}.
+           tab => Tab,
+           ack_pid => AckPid,
+           other_servers => [],
+           %% Initial join_ref is random
+           join_ref => make_ref(),
+           leader => self(),
+           is_leader => true,
+           opts => Opts,
+           backlog => [],
+           pause_monitors => []
+          }}.
 
 -spec handle_call(long_msg() | {op, op()}, from(), state()) ->
-    {noreply, state()} | {reply, term(), state()}.
+          {noreply, state()} | {reply, term(), state()}.
 handle_call({op, Op}, From, State = #{pause_monitors := []}) ->
     handle_op(Op, From, State),
     {noreply, State};
@@ -362,9 +362,9 @@ handle_call(get_leader, _From, State = #{leader := Leader}) ->
 handle_call(sync, From, State = #{other_servers := Servers}) ->
     %% Do spawn to avoid any possible deadlocks
     proc_lib:spawn(fun() ->
-        lists:foreach(fun ping/1, Servers),
-        gen_server:reply(From, ok)
-    end),
+                           lists:foreach(fun ping/1, Servers),
+                           gen_server:reply(From, ok)
+                   end),
     {noreply, State};
 handle_call(ping, _From, State) ->
     {reply, pong, State};
@@ -424,10 +424,10 @@ handle_down(Mon, Pid, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
         true ->
             Log = #{
-                what => pause_owner_crashed,
-                state => State,
-                paused_by_pid => Pid
-            },
+                    what => pause_owner_crashed,
+                    state => State,
+                    paused_by_pid => Pid
+                   },
             ?LOG_ERROR(Log),
             handle_unpause2(Mon, Mons, State);
         false ->
@@ -445,10 +445,10 @@ handle_down2(RemotePid, State = #{other_servers := Servers, ack_pid := AckPid}) 
         false ->
             %% This should not happen
             Log = #{
-                what => handle_down_failed,
-                remote_pid => RemotePid,
-                state => State
-            },
+                    what => handle_down_failed,
+                    remote_pid => RemotePid,
+                    state => State
+                   },
             ?LOG_ERROR(Log),
             State
     end.
@@ -467,11 +467,11 @@ add_servers(Pids, Servers) ->
             %% Should not happen (cets_join checks for it)
             %% Still log it, if that happens
             Log = #{
-                what => already_added,
-                already_added_servers => Overlap,
-                pids => Pids,
-                servers => Servers
-            },
+                    what => already_added,
+                    already_added_servers => Overlap,
+                    pids => Pids,
+                    servers => Servers
+                   },
             ?LOG_ERROR(Log)
     end,
     [erlang:monitor(process, Pid) || Pid <- NewServers],
@@ -513,12 +513,12 @@ handle_remote_op(Op, From, AckPid, JoinRef, State = #{join_ref := JoinRef}) ->
     cets_ack:ack(AckPid, From, self());
 handle_remote_op(Op, From, AckPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
     Log = #{
-        what => drop_remote_op,
-        from => From,
-        remote_join_ref => RemoteJoinRef,
-        join_ref => JoinRef,
-        op => Op
-    },
+            what => drop_remote_op,
+            from => From,
+            remote_join_ref => RemoteJoinRef,
+            join_ref => JoinRef,
+            op => Op
+           },
     ?LOG_ERROR(Log),
     %% We still need to reply to the remote process so it could stop waiting
     cets_ack:ack(AckPid, From, self()).
@@ -591,7 +591,7 @@ apply_backlog(State = #{backlog := Backlog}) ->
 %% We support multiple pauses
 %% Only when all pause requests are unpaused we continue
 -spec handle_unpause(pause_monitor(), state()) -> {reply, Reply, state()} when
-    Reply :: ok | {error, unknown_pause_monitor}.
+      Reply :: ok | {error, unknown_pause_monitor}.
 handle_unpause(Mon, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
         true ->
@@ -630,12 +630,12 @@ handle_check_server(_FromPid, JoinRef, #{join_ref := JoinRef}) ->
     ok;
 handle_check_server(FromPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
     Log = #{
-        what => cets_check_server_failed,
-        text => <<"Disconnect the remote server">>,
-        remote_pid => FromPid,
-        remote_join_ref => RemoteJoinRef,
-        join_ref => JoinRef
-    },
+            what => cets_check_server_failed,
+            text => <<"Disconnect the remote server">>,
+            remote_pid => FromPid,
+            remote_join_ref => RemoteJoinRef,
+            join_ref => JoinRef
+           },
     ?LOG_WARNING(Log),
     %% Ask the remote server to disconnect from us
     Reason = {check_server_failed, {RemoteJoinRef, JoinRef}},
@@ -644,23 +644,23 @@ handle_check_server(FromPid, RemoteJoinRef, #{join_ref := JoinRef}) ->
 
 -spec handle_get_info(state()) -> info().
 handle_get_info(
+  #{
+    tab := Tab,
+    other_servers := Servers,
+    ack_pid := AckPid,
+    join_ref := JoinRef,
+    opts := Opts
+   }
+ ) ->
     #{
-        tab := Tab,
-        other_servers := Servers,
-        ack_pid := AckPid,
-        join_ref := JoinRef,
-        opts := Opts
-    }
-) ->
-    #{
-        table => Tab,
-        nodes => lists:usort(pids_to_nodes([self() | Servers])),
-        size => ets:info(Tab, size),
-        memory => ets:info(Tab, memory),
-        ack_pid => AckPid,
-        join_ref => JoinRef,
-        opts => Opts
-    }.
+      table => Tab,
+      nodes => lists:usort(pids_to_nodes([self() | Servers])),
+      size => ets:info(Tab, size),
+      memory => ets:info(Tab, memory),
+      ack_pid => AckPid,
+      join_ref => JoinRef,
+      opts => Opts
+     }.
 
 %% Cleanup
 -spec call_user_handle_down(server_pid(), state()) -> ok.
@@ -669,11 +669,11 @@ call_user_handle_down(RemotePid, #{tab := Tab, opts := Opts}) ->
         #{handle_down := F} ->
             FF = fun() -> F(#{remote_pid => RemotePid, table => Tab}) end,
             Info = #{
-                task => call_user_handle_down,
-                table => Tab,
-                remote_pid => RemotePid,
-                remote_node => node(RemotePid)
-            },
+                     task => call_user_handle_down,
+                     table => Tab,
+                     remote_pid => RemotePid,
+                     remote_node => node(RemotePid)
+                    },
             %% Errors would be logged inside run_tracked
             catch cets_long:run_tracked(Info, FF);
         _ ->

--- a/src/cets_ack.erl
+++ b/src/cets_ack.erl
@@ -8,22 +8,22 @@
 
 %% API functions
 -export([
-    start_link/1,
-    set_servers/2,
-    add/2,
-    ack/3,
-    send_remote_down/2
-]).
+         start_link/1,
+         set_servers/2,
+         add/2,
+         ack/3,
+         send_remote_down/2
+        ]).
 
 %% gen_server callbacks
 -export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
-]).
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3
+        ]).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -31,10 +31,10 @@
 -type server_pid() :: cets:server_pid().
 -type from() :: gen_server:from().
 -type state() :: #{
-    servers := [server_pid()],
-    %% We store tasks directly in the state map
-    from() => [server_pid(), ...]
-}.
+                   servers := [server_pid()],
+                   %% We store tasks directly in the state map
+                   from() => [server_pid(), ...]
+                  }.
 
 -export_type([ack_pid/0]).
 
@@ -117,13 +117,13 @@ handle_add(_, _) ->
 handle_remote_down(RemotePid, State) ->
     %% Call handle_updated for all pending tasks
     F = fun
-        (Key, _Value, State2) when is_atom(Key) ->
-            %% Ignore keys that are not used for tasks (i.e. servers key)
-            State2;
+            (Key, _Value, State2) when is_atom(Key) ->
+                %% Ignore keys that are not used for tasks (i.e. servers key)
+                                             State2;
         (From, Servers, State2) ->
-            handle_updated(From, RemotePid, Servers, State2)
-    end,
-    maps:fold(F, State, State).
+                                             handle_updated(From, RemotePid, Servers, State2)
+                                     end,
+maps:fold(F, State, State).
 
 -spec handle_updated(from(), server_pid(), state()) -> state().
 handle_updated(From, RemotePid, State) ->

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -69,12 +69,12 @@ send_leader_op(Server, Op, Backoff) ->
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
             Log = #{
-                what => wrong_leader,
-                server => Server,
-                operation => Op,
-                called_leader => Leader,
-                expected_leader => ExpectedLeader
-            },
+                    what => wrong_leader,
+                    server => Server,
+                    operation => Op,
+                    called_leader => Leader,
+                    expected_leader => ExpectedLeader
+                   },
             ?LOG_WARNING(Log),
             %% This could happen if a new node joins the cluster.
             %% So, a simple retry should help.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -5,13 +5,13 @@
 
 -export([start/1, start_link/1, add_table/2, info/1]).
 -export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
-]).
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3
+        ]).
 
 -ignore_xref([start/1, start_link/1, add_table/2, info/1, behaviour_info/1]).
 
@@ -24,12 +24,12 @@
 
 -type from() :: {pid(), reference()}.
 -type state() :: #{
-    results := [term()],
-    tables := [atom()],
-    backend_module := module(),
-    backend_state := state(),
-    timer_ref := reference() | undefined
-}.
+                   results := [term()],
+                   tables := [atom()],
+                   backend_module := module(),
+                   backend_state := state(),
+                   timer_ref := reference() | undefined
+                  }.
 
 %% Backend could define its own options
 -type opts() :: #{name := atom(), _ := _}.
@@ -77,12 +77,12 @@ init(Opts) ->
     Tables = maps:get(tables, Opts, []),
     BackendState = Mod:init(Opts),
     {ok, #{
-        results => [],
-        tables => Tables,
-        backend_module => Mod,
-        backend_state => BackendState,
-        timer_ref => undefined
-    }}.
+           results => [],
+           tables => Tables,
+           backend_module => Mod,
+           backend_state => BackendState,
+           timer_ref => undefined
+          }}.
 
 -spec handle_call(term(), from(), state()) -> {reply, term(), state()}.
 handle_call({add_table, Table}, _From, State = #{tables := Tables}) ->

--- a/src/cets_discovery_file.erl
+++ b/src/cets_discovery_file.erl
@@ -24,10 +24,10 @@ get_nodes(State = #{disco_file := Filename}) ->
     case file:read_file(Filename) of
         {error, Reason} ->
             Log = #{
-                what => discovery_failed,
-                filename => Filename,
-                reason => Reason
-            },
+                    what => discovery_failed,
+                    filename => Filename,
+                    reason => Reason
+                   },
             ?LOG_ERROR(Log),
             {{error, Reason}, State};
         {ok, Text} ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -11,12 +11,12 @@
 
 %% Critical events during the joining procedure
 -type checkpoint() ::
-    join_start
-    | before_retry
-    | before_get_pids
-    | before_check_fully_connected
-    | before_unpause
-    | {before_send_dump, server_pid()}.
+        join_start
+      | before_retry
+      | before_get_pids
+      | before_check_fully_connected
+      | before_unpause
+      | {before_send_dump, server_pid()}.
 
 -type checkpoint_handler() :: fun((checkpoint()) -> ok).
 -type join_opts() :: #{checkpoint_handler => checkpoint_handler()}.
@@ -29,7 +29,7 @@
 %% Writes from other nodes would wait for join completion.
 %% LockKey should be the same on all nodes.
 -spec join(lock_key(), cets_long:log_info(), server_pid(), server_pid()) ->
-    ok | {error, term()}.
+          ok | {error, term()}.
 join(LockKey, Info, LocalPid, RemotePid) ->
     join(LockKey, Info, LocalPid, RemotePid, #{}).
 
@@ -38,10 +38,10 @@ join(_LockKey, _Info, Pid, Pid, _JoinOpts) when is_pid(Pid) ->
     {error, join_with_the_same_pid};
 join(LockKey, Info, LocalPid, RemotePid, JoinOpts) when is_pid(LocalPid), is_pid(RemotePid) ->
     Info2 = Info#{
-        local_pid => LocalPid,
-        remote_pid => RemotePid,
-        remote_node => node(RemotePid)
-    },
+                  local_pid => LocalPid,
+                  remote_pid => RemotePid,
+                  remote_node => node(RemotePid)
+                 },
     F = fun() -> join1(LockKey, Info2, LocalPid, RemotePid, JoinOpts) end,
     try
         cets_long:run_tracked(Info2#{long_task_name => join}, F)
@@ -68,13 +68,13 @@ join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts) ->
     %% - for performance reasons, we don't want to cause too much load for active nodes
     %% - to avoid deadlocks, because joining does gen_server calls
     F = fun() ->
-        Diff = erlang:system_time(millisecond) - Start,
-        %% Getting the lock could take really long time in case nodes are
-        %% overloaded or joining is already in progress on another node
-        ?LOG_INFO(Info#{what => join_got_lock, after_time_ms => Diff}),
-        %% Do joining in a separate process to reduce GC
-        cets_long:run_spawn(Info, fun() -> join2(LocalPid, RemotePid, JoinOpts) end)
-    end,
+                Diff = erlang:system_time(millisecond) - Start,
+                %% Getting the lock could take really long time in case nodes are
+                %% overloaded or joining is already in progress on another node
+                ?LOG_INFO(Info#{what => join_got_lock, after_time_ms => Diff}),
+                %% Do joining in a separate process to reduce GC
+                cets_long:run_spawn(Info, fun() -> join2(LocalPid, RemotePid, JoinOpts) end)
+        end,
     LockRequest = {LockKey, self()},
     %% Just lock all nodes, no magic here :)
     Nodes = [node() | nodes()],
@@ -157,21 +157,21 @@ apply_resolver_for_sorted([X | LocalDump], [X | RemoteDump], F, Pos, LocalAcc, R
     %% Presents in both dumps, skip it at all (we don't need to insert it, it is already inserted)
     apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, LocalAcc, RemoteAcc);
 apply_resolver_for_sorted(
-    [L | LocalDump] = LocalDumpFull,
-    [R | RemoteDump] = RemoteDumpFull,
-    F,
-    Pos,
-    LocalAcc,
-    RemoteAcc
-) ->
+  [L | LocalDump] = LocalDumpFull,
+  [R | RemoteDump] = RemoteDumpFull,
+  F,
+  Pos,
+  LocalAcc,
+  RemoteAcc
+ ) ->
     LKey = element(Pos, L),
     RKey = element(Pos, R),
     if
         LKey =:= RKey ->
             New = F(L, R),
             apply_resolver_for_sorted(LocalDump, RemoteDump, F, Pos, [New | LocalAcc], [
-                New | RemoteAcc
-            ]);
+                                                                                        New | RemoteAcc
+                                                                                       ]);
         LKey < RKey ->
             %% Record exists only in the local dump
             apply_resolver_for_sorted(LocalDump, RemoteDumpFull, F, Pos, [L | LocalAcc], RemoteAcc);
@@ -200,11 +200,11 @@ check_do_not_overlap(LocPids, RemPids) ->
             ok;
         Overlap ->
             Log = #{
-                what => check_do_not_overlap_failed,
-                local_servers => LocPids,
-                remote_servers => RemPids,
-                overlapped_servers => Overlap
-            },
+                    what => check_do_not_overlap_failed,
+                    local_servers => LocPids,
+                    remote_servers => RemPids,
+                    overlapped_servers => Overlap
+                   },
             ?LOG_ERROR(Log),
             error(check_do_not_overlap_failed)
     end.
@@ -219,10 +219,10 @@ check_fully_connected(Pids) ->
             check_same_join_ref(Pids);
         false ->
             Log = #{
-                what => check_fully_connected_failed,
-                expected_pids => Pids,
-                server_lists => Lists
-            },
+                    what => check_fully_connected_failed,
+                    expected_pids => Pids,
+                    server_lists => Lists
+                   },
             ?LOG_ERROR(Log),
             error(check_fully_connected_failed)
     end.
@@ -240,9 +240,9 @@ check_same_join_ref(Pids) ->
             ok;
         _ ->
             Log = #{
-                what => check_same_join_ref_failed,
-                refs => lists:zip(Pids, Refs)
-            },
+                    what => check_same_join_ref_failed,
+                    refs => lists:zip(Pids, Refs)
+                   },
             ?LOG_ERROR(Log),
             error(check_same_join_ref_failed)
     end.

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -20,14 +20,14 @@ run_spawn(Info, F) ->
     Pid = self(),
     Ref = make_ref(),
     proc_lib:spawn_link(fun() ->
-        try run_tracked(Info, F) of
-            Res ->
-                Pid ! {result, Ref, Res}
-        catch
-            Class:Reason:Stacktrace ->
-                Pid ! {forward_error, Ref, {Class, Reason, Stacktrace}}
-        end
-    end),
+                                try run_tracked(Info, F) of
+                                    Res ->
+                                        Pid ! {result, Ref, Res}
+                                catch
+                                    Class:Reason:Stacktrace ->
+                                        Pid ! {forward_error, Ref, {Class, Reason, Stacktrace}}
+                                end
+                        end),
     receive
         {result, Ref, Res} ->
             Res;
@@ -51,11 +51,11 @@ run_tracked(Info, Fun) ->
     catch
         Class:Reason:Stacktrace ->
             Log = Info#{
-                what => long_task_failed,
-                class => Class,
-                reason => Reason,
-                stacktrace => Stacktrace
-            },
+                        what => long_task_failed,
+                        class => Class,
+                        reason => Reason,
+                        stacktrace => Stacktrace
+                       },
             ?LOG_ERROR(Log),
             erlang:raise(Class, Reason, Stacktrace)
     after
@@ -79,9 +79,9 @@ monitor_loop(Mon, Info, Start) ->
         stop ->
             ok
     after 5000 ->
-        Diff = diff(Start),
-        ?LOG_INFO(Info#{what => long_task_progress, time_ms => Diff}),
-        monitor_loop(Mon, Info, Start)
+            Diff = diff(Start),
+            ?LOG_INFO(Info#{what => long_task_progress, time_ms => Diff}),
+            monitor_loop(Mon, Info, Start)
     end.
 
 diff(Start) ->

--- a/src/cets_metadata.erl
+++ b/src/cets_metadata.erl
@@ -1,9 +1,9 @@
 -module(cets_metadata).
 -export([
-    init/1,
-    set/3,
-    get/2
-]).
+         init/1,
+         set/3,
+         get/2
+        ]).
 
 init(Name) ->
     FullName = name(Name),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -5,78 +5,78 @@
 
 all() ->
     [
-        inserted_records_could_be_read_back,
-        insert_many_with_one_record,
-        insert_many_with_two_records,
-        delete_works,
-        delete_many_works,
-        join_works,
-        inserted_records_could_be_read_back_from_replicated_table,
-        join_works_with_existing_data,
-        join_works_with_existing_data_with_conflicts,
-        join_works_with_existing_data_with_conflicts_and_defined_conflict_handler,
-        join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_more_keys,
-        join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_keypos2,
-        bag_with_conflict_handler_not_allowed,
-        insert_new_works,
-        insert_new_works_with_table_name,
-        insert_new_works_when_leader_is_back,
-        insert_new_when_new_leader_has_joined,
-        insert_new_when_new_leader_has_joined_duplicate,
-        insert_new_when_inconsistent,
-        insert_new_is_retried_when_leader_is_reelected,
-        insert_new_fails_if_the_leader_dies,
-        insert_new_fails_if_the_local_server_is_dead,
-        leader_is_the_same_in_metadata_after_join,
-        join_with_the_same_pid,
-        join_ref_is_same_after_join,
-        join_fails_because_server_process_not_found,
-        join_fails_because_server_process_not_found_before_get_pids,
-        join_fails_before_send_dump,
-        join_fails_before_send_dump_and_there_are_pending_remote_ops,
-        send_dump_fails_during_join_because_receiver_exits,
-        join_fails_in_check_fully_connected,
-        join_fails_because_join_refs_do_not_match_for_nodes_in_segment,
-        join_fails_because_pids_do_not_match_for_nodes_in_segment,
-        join_fails_because_servers_overlap,
-        remote_ops_are_ignored_if_join_ref_does_not_match,
-        join_retried_if_lock_is_busy,
-        send_dump_contains_already_added_servers,
-        test_multinode,
-        test_multinode_remote_insert,
-        node_list_is_correct,
-        test_multinode_auto_discovery,
-        test_locally,
-        handle_down_is_called,
-        events_are_applied_in_the_correct_order_after_unpause,
-        pause_multiple_times,
-        unpause_twice,
-        unpause_if_pause_owner_crashes,
-        write_returns_if_remote_server_crashes,
-        ack_process_stops_correctly,
-        ack_process_handles_unknown_remote_server,
-        ack_process_handles_unknown_from,
-        ack_calling_add_when_server_list_is_empty_is_not_allowed,
-        sync_using_name_works,
-        insert_many_request,
-        insert_into_bag,
-        delete_from_bag,
-        delete_many_from_bag,
-        delete_request_from_bag,
-        delete_request_many_from_bag,
-        insert_into_bag_is_replicated,
-        insert_into_keypos_table,
-        table_name_works,
-        info_contains_opts,
-        unknown_down_message_is_ignored,
-        unknown_message_is_ignored,
-        unknown_cast_message_is_ignored,
-        unknown_message_is_ignored_in_ack_process,
-        unknown_cast_message_is_ignored_in_ack_process,
-        unknown_call_returns_error_from_ack_process,
-        code_change_returns_ok,
-        code_change_returns_ok_for_ack,
-        run_spawn_forwards_errors
+     inserted_records_could_be_read_back,
+     insert_many_with_one_record,
+     insert_many_with_two_records,
+     delete_works,
+     delete_many_works,
+     join_works,
+     inserted_records_could_be_read_back_from_replicated_table,
+     join_works_with_existing_data,
+     join_works_with_existing_data_with_conflicts,
+     join_works_with_existing_data_with_conflicts_and_defined_conflict_handler,
+     join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_more_keys,
+     join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_keypos2,
+     bag_with_conflict_handler_not_allowed,
+     insert_new_works,
+     insert_new_works_with_table_name,
+     insert_new_works_when_leader_is_back,
+     insert_new_when_new_leader_has_joined,
+     insert_new_when_new_leader_has_joined_duplicate,
+     insert_new_when_inconsistent,
+     insert_new_is_retried_when_leader_is_reelected,
+     insert_new_fails_if_the_leader_dies,
+     insert_new_fails_if_the_local_server_is_dead,
+     leader_is_the_same_in_metadata_after_join,
+     join_with_the_same_pid,
+     join_ref_is_same_after_join,
+     join_fails_because_server_process_not_found,
+     join_fails_because_server_process_not_found_before_get_pids,
+     join_fails_before_send_dump,
+     join_fails_before_send_dump_and_there_are_pending_remote_ops,
+     send_dump_fails_during_join_because_receiver_exits,
+     join_fails_in_check_fully_connected,
+     join_fails_because_join_refs_do_not_match_for_nodes_in_segment,
+     join_fails_because_pids_do_not_match_for_nodes_in_segment,
+     join_fails_because_servers_overlap,
+     remote_ops_are_ignored_if_join_ref_does_not_match,
+     join_retried_if_lock_is_busy,
+     send_dump_contains_already_added_servers,
+     test_multinode,
+     test_multinode_remote_insert,
+     node_list_is_correct,
+     test_multinode_auto_discovery,
+     test_locally,
+     handle_down_is_called,
+     events_are_applied_in_the_correct_order_after_unpause,
+     pause_multiple_times,
+     unpause_twice,
+     unpause_if_pause_owner_crashes,
+     write_returns_if_remote_server_crashes,
+     ack_process_stops_correctly,
+     ack_process_handles_unknown_remote_server,
+     ack_process_handles_unknown_from,
+     ack_calling_add_when_server_list_is_empty_is_not_allowed,
+     sync_using_name_works,
+     insert_many_request,
+     insert_into_bag,
+     delete_from_bag,
+     delete_many_from_bag,
+     delete_request_from_bag,
+     delete_request_many_from_bag,
+     insert_into_bag_is_replicated,
+     insert_into_keypos_table,
+     table_name_works,
+     info_contains_opts,
+     unknown_down_message_is_ignored,
+     unknown_message_is_ignored,
+     unknown_cast_message_is_ignored,
+     unknown_message_is_ignored_in_ack_process,
+     unknown_cast_message_is_ignored_in_ack_process,
+     unknown_call_returns_error_from_ack_process,
+     code_change_returns_ok,
+     code_change_returns_ok_for_ack,
+     run_spawn_forwards_errors
     ].
 
 init_per_suite(Config) ->
@@ -165,9 +165,9 @@ insert_new_works_when_leader_is_back(_Config) ->
     Pid2 = Leader,
     cets:set_leader(Leader, false),
     spawn(fun() ->
-        timer:sleep(100),
-        cets:set_leader(Leader, true)
-    end),
+                  timer:sleep(100),
+                  cets:set_leader(Leader, true)
+          end),
     true = cets:insert_new(Pid1, {alice, 32}).
 
 insert_new_when_new_leader_has_joined(_Config) ->
@@ -180,10 +180,10 @@ insert_new_when_new_leader_has_joined(_Config) ->
     Leader = cets:get_leader(Pid1),
     PauseMon = cets:pause(Leader),
     spawn(fun() ->
-        timer:sleep(100),
-        ok = cets_join:join(insert_new_lock4, #{}, Pid1, Pid3),
-        cets:unpause(Leader, PauseMon)
-    end),
+                  timer:sleep(100),
+                  ok = cets_join:join(insert_new_lock4, #{}, Pid1, Pid3),
+                  cets:unpause(Leader, PauseMon)
+          end),
     %% Inserted by Pid3
     true = cets:insert_new(Pid1, {alice, 32}),
     Res = [{alice, 32}],
@@ -202,10 +202,10 @@ insert_new_when_new_leader_has_joined_duplicate(_Config) ->
     Leader = cets:get_leader(Pid1),
     PauseMon = cets:pause(Leader),
     spawn(fun() ->
-        timer:sleep(100),
-        ok = cets_join:join(insert_new_lock5, #{}, Pid1, Pid3),
-        cets:unpause(Leader, PauseMon)
-    end),
+                  timer:sleep(100),
+                  ok = cets_join:join(insert_new_lock5, #{}, Pid1, Pid3),
+                  cets:unpause(Leader, PauseMon)
+          end),
     %% Checked and ignored by Pid3
     false = cets:insert_new(Pid1, {alice, 32}),
     Res = [{alice, 33}],
@@ -237,10 +237,10 @@ insert_new_is_retried_when_leader_is_reelected(_Config) ->
     %% Ask process to reject all the leader operations
     cets:set_leader(Leader, false),
     spawn(fun() ->
-        timer:sleep(100),
-        %% Fix the leader, so it can process our insert_new call
-        cets:set_leader(Leader, true)
-    end),
+                  timer:sleep(100),
+                  %% Fix the leader, so it can process our insert_new call
+                  cets:set_leader(Leader, true)
+          end),
     %% This function would block, because Leader process would reject the operation
     %% Until we call cets:set_leader(Leader, true)
     true = cets:insert_new(Pid1, {alice, 32}),
@@ -250,7 +250,7 @@ insert_new_is_retried_when_leader_is_reelected(_Config) ->
         {wrong_leader_detected, Info} ->
             ct:pal("wrong_leader_detected ~p", [Info])
     after 5000 ->
-        ct:fail(wrong_leader_not_detected)
+            ct:fail(wrong_leader_not_detected)
     end,
     %% Check that data is written (i.e. retry works)
     {ok, [{alice, 32}]} = cets:remote_dump(Pid1),
@@ -268,9 +268,9 @@ insert_new_fails_if_the_leader_dies(_Config) ->
     ok = cets_join:join(join_lock1_insnew_back3, #{}, Pid1, Pid2),
     cets:pause(Pid2),
     spawn(fun() ->
-        timer:sleep(100),
-        exit(Pid2, kill)
-    end),
+                  timer:sleep(100),
+                  exit(Pid2, kill)
+          end),
     try
         cets:insert_new(Pid1, {alice, 32})
     catch
@@ -366,8 +366,8 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_ke
 
 %% Keep record with highest timestamp
 resolve_user_conflict(U1 = #user{updated = TS1}, _U2 = #user{updated = TS2}) when
-    TS1 > TS2
-->
+      TS1 > TS2
+      ->
     U1;
 resolve_user_conflict(_U1, U2) ->
     U2.
@@ -400,58 +400,58 @@ join_fails_because_server_process_not_found(Config) ->
     {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     F = fun
-        (join_start) ->
-            exit(Pid1, sim_error);
+            (join_start) ->
+                                                            exit(Pid1, sim_error);
         (_) ->
-            ok
-    end,
-    {error, {noproc, {gen_server, call, [Pid1, get_info, infinity]}}} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
+                                                            ok
+                                                    end,
+{error, {noproc, {gen_server, call, [Pid1, get_info, infinity]}}} =
+cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
 
 join_fails_because_server_process_not_found_before_get_pids(Config) ->
     {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     F = fun
-        (before_get_pids) ->
-            exit(Pid1, sim_error);
+            (before_get_pids) ->
+                                                                            exit(Pid1, sim_error);
         (_) ->
-            ok
-    end,
-    {error, {noproc, {gen_server, call, [Pid1, other_servers, infinity]}}} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
+                                                                            ok
+                                                                    end,
+{error, {noproc, {gen_server, call, [Pid1, other_servers, infinity]}}} =
+cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
 
 join_fails_before_send_dump(Config) ->
     Me = self(),
     DownFn = fun(#{remote_pid := RemotePid, table := _Tab}) ->
-        Me ! {down_called, self(), RemotePid}
-    end,
+                     Me ! {down_called, self(), RemotePid}
+             end,
     {ok, Pid1} = cets:start(make_name(Config, 1), #{handle_down => DownFn}),
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     cets:insert(Pid1, {1}),
     cets:insert(Pid2, {2}),
     F = fun
-        ({before_send_dump, P}) when Pid1 =:= P ->
-            Me ! before_send_dump_called_for_pid1;
+            ({before_send_dump, P}) when Pid1 =:= P ->
+                                            Me ! before_send_dump_called_for_pid1;
         ({before_send_dump, P}) when Pid2 =:= P ->
-            error(sim_error);
+                                            error(sim_error);
         (_) ->
-            ok
-    end,
-    {error, sim_error} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
-    %% Ensure we sent dump to Pid1
-    receive_message(before_send_dump_called_for_pid1),
-    %% Not joined, some data exchanged
-    cets:sync(Pid1),
-    cets:sync(Pid2),
-    [] = cets:other_pids(Pid1),
-    [] = cets:other_pids(Pid2),
-    %% Pid1 applied new version of dump
-    %% Though, it got disconnected after
-    {ok, [{1}, {2}]} = cets:remote_dump(Pid1),
-    %% Pid2 rejected changes
-    {ok, [{2}]} = cets:remote_dump(Pid2),
-    receive_message({down_called, Pid1, Pid2}).
+                                            ok
+                                    end,
+{error, sim_error} =
+cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
+%% Ensure we sent dump to Pid1
+receive_message(before_send_dump_called_for_pid1),
+%% Not joined, some data exchanged
+cets:sync(Pid1),
+cets:sync(Pid2),
+[] = cets:other_pids(Pid1),
+[] = cets:other_pids(Pid2),
+%% Pid1 applied new version of dump
+%% Though, it got disconnected after
+{ok, [{1}, {2}]} = cets:remote_dump(Pid1),
+%% Pid2 rejected changes
+{ok, [{2}]} = cets:remote_dump(Pid2),
+receive_message({down_called, Pid1, Pid2}).
 
 %% Checks that remote ops are dropped if join_ref does not match in the state and in remote_op message
 join_fails_before_send_dump_and_there_are_pending_remote_ops(Config) ->
@@ -459,60 +459,60 @@ join_fails_before_send_dump_and_there_are_pending_remote_ops(Config) ->
     {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     F = fun
-        ({before_send_dump, P}) when Pid1 =:= P ->
-            Me ! before_send_dump_called_for_pid1;
+            ({before_send_dump, P}) when Pid1 =:= P ->
+                                                                             Me ! before_send_dump_called_for_pid1;
         ({before_send_dump, P}) when Pid2 =:= P ->
-            sys:suspend(Pid2),
-            error(sim_error);
+                                                                             sys:suspend(Pid2),
+                                                                             error(sim_error);
         (before_unpause) ->
-            %% Crash in before_unpause, otherwise cets_join will block in cets:unpause/2
-            %% (because Pid2 is suspended).
-            %% Servers would be unpaused automatically though, because cets_join process exits
-            %% (i.e. cets:unpause/2 call is totally optional)
-            error(sim_error2);
+                %% Crash in before_unpause, otherwise cets_join will block in cets:unpause/2
+                %% (because Pid2 is suspended).
+                %% Servers would be unpaused automatically though, because cets_join process exits
+                %% (i.e. cets:unpause/2 call is totally optional)
+                                                                             error(sim_error2);
         (_) ->
-            ok
-    end,
-    {error, sim_error2} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
-    %% Ensure we sent dump to Pid1
-    receive_message(before_send_dump_called_for_pid1),
-    cets:insert_request(Pid1, {1}),
-    %% Check that the remote_op has reached Pid2 message box
-    cets_test_wait:wait_until(fun() -> count_remote_ops_in_the_message_box(Pid2) end, 1),
-    sys:resume(Pid2),
-    %% Wait till remote_op is processed
-    cets:ping(Pid2),
-    %% Check that the insert was ignored
-    {ok, []} = cets:remote_dump(Pid2).
+                                                                             ok
+                                                                     end,
+{error, sim_error2} =
+cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
+%% Ensure we sent dump to Pid1
+receive_message(before_send_dump_called_for_pid1),
+cets:insert_request(Pid1, {1}),
+%% Check that the remote_op has reached Pid2 message box
+cets_test_wait:wait_until(fun() -> count_remote_ops_in_the_message_box(Pid2) end, 1),
+sys:resume(Pid2),
+%% Wait till remote_op is processed
+cets:ping(Pid2),
+%% Check that the insert was ignored
+{ok, []} = cets:remote_dump(Pid2).
 
 send_dump_fails_during_join_because_receiver_exits(Config) ->
     Me = self(),
     DownFn = fun(#{remote_pid := RemotePid, table := _Tab}) ->
-        Me ! {down_called, self(), RemotePid}
-    end,
+                     Me ! {down_called, self(), RemotePid}
+             end,
     {ok, Pid1} = cets:start(make_name(Config, 1), #{handle_down => DownFn}),
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     F = fun
-        ({before_send_dump, P}) when P =:= Pid1 ->
-            %% Kill Pid2 process.
-            %% It does not crash the join process.
-            %% Pid1 would receive a dump with Pid2 in the server list.
-            exit(Pid2, sim_error),
-            %% Ensure Pid1 got DOWN message from Pid2 already
-            pong = cets:ping(Pid1),
-            Me ! before_send_dump_called;
+            ({before_send_dump, P}) when P =:= Pid1 ->
+                %% Kill Pid2 process.
+                %% It does not crash the join process.
+                %% Pid1 would receive a dump with Pid2 in the server list.
+                                                                   exit(Pid2, sim_error),
+                %% Ensure Pid1 got DOWN message from Pid2 already
+                                                                   pong = cets:ping(Pid1),
+                                                                   Me ! before_send_dump_called;
         (_) ->
-            ok
-    end,
-    ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
-    receive_message(before_send_dump_called),
-    pong = cets:ping(Pid1),
-    receive_message({down_called, Pid1, Pid2}),
-    [] = cets:other_pids(Pid1),
-    %% Pid1 still works
-    cets:insert(Pid1, {1}),
-    {ok, [{1}]} = cets:remote_dump(Pid1).
+                                                                   ok
+                                                           end,
+ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
+receive_message(before_send_dump_called),
+pong = cets:ping(Pid1),
+receive_message({down_called, Pid1, Pid2}),
+[] = cets:other_pids(Pid1),
+%% Pid1 still works
+cets:insert(Pid1, {1}),
+{ok, [{1}]} = cets:remote_dump(Pid1).
 
 join_fails_in_check_fully_connected(Config) ->
     Me = self(),
@@ -523,19 +523,19 @@ join_fails_in_check_fully_connected(Config) ->
     ok = cets_join:join(lock_name(Config), #{}, Pid2, Pid3, #{}),
     [Pid3] = cets:other_pids(Pid2),
     F = fun
-        (before_check_fully_connected) ->
-            %% Ask Pid2 to remove Pid3 from the list
-            Pid2 ! {'DOWN', make_ref(), process, Pid3, sim_error},
-            %% Ensure Pid2 did the cleaning
-            pong = cets:ping(Pid2),
-            [] = cets:other_pids(Pid2),
-            Me ! before_check_fully_connected_called;
+            (before_check_fully_connected) ->
+                %% Ask Pid2 to remove Pid3 from the list
+                                                    Pid2 ! {'DOWN', make_ref(), process, Pid3, sim_error},
+                %% Ensure Pid2 did the cleaning
+                                                    pong = cets:ping(Pid2),
+                                                    [] = cets:other_pids(Pid2),
+                                                    Me ! before_check_fully_connected_called;
         (_) ->
-            ok
-    end,
-    {error, check_fully_connected_failed} =
-        cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
-    receive_message(before_check_fully_connected_called).
+                                                    ok
+                                            end,
+{error, check_fully_connected_failed} =
+cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}),
+receive_message(before_check_fully_connected_called).
 
 join_fails_because_join_refs_do_not_match_for_nodes_in_segment(Config) ->
     {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
@@ -588,26 +588,26 @@ join_retried_if_lock_is_busy(Config) ->
     {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
     Lock = lock_name(Config),
     SleepyF = fun
-        (join_start) ->
-            Me ! join_start,
-            timer:sleep(infinity);
+                  (join_start) ->
+                                             Me ! join_start,
+                                             timer:sleep(infinity);
         (_) ->
-            ok
-    end,
-    F = fun
+                                             ok
+                                     end,
+F = fun
         (before_retry) -> Me ! before_retry;
         (_) -> ok
     end,
     %% Get the lock in a separate process
-    spawn_link(fun() ->
-        cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => SleepyF})
-    end),
-    receive_message(join_start),
-    %% We actually would not return from cets_join:join unless we get the lock
-    spawn_link(fun() ->
-        ok = cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => F})
-    end),
-    receive_message(before_retry).
+spawn_link(fun() ->
+                   cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => SleepyF})
+           end),
+receive_message(join_start),
+%% We actually would not return from cets_join:join unless we get the lock
+spawn_link(fun() ->
+                   ok = cets_join:join(Lock, #{}, Pid1, Pid2, #{checkpoint_handler => F})
+           end),
+receive_message(before_retry).
 
 send_dump_contains_already_added_servers(Config) ->
     %% Check that even if we have already added server in send_dump, nothing crashes
@@ -642,12 +642,12 @@ test_multinode(Config) ->
     insert(Node1, Tab, {f}),
     insert(Node4, Tab, {e}),
     Same = fun(X) ->
-        X = dump(Node1, Tab),
-        X = dump(Node2, Tab),
-        X = dump(Node3, Tab),
-        X = dump(Node4, Tab),
-        ok
-    end,
+                   X = dump(Node1, Tab),
+                   X = dump(Node2, Tab),
+                   X = dump(Node3, Tab),
+                   X = dump(Node4, Tab),
+                   ok
+           end,
     Same([{a}, {b}, {c}, {d}, {e}, {f}]),
     delete(Node1, Tab, e),
     Same([{a}, {b}, {c}, {d}, {f}]),
@@ -720,8 +720,8 @@ test_locally(_Config) ->
 handle_down_is_called(_Config) ->
     Parent = self(),
     DownFn = fun(#{remote_pid := _RemotePid, table := _Tab}) ->
-        Parent ! down_called
-    end,
+                     Parent ! down_called
+             end,
     {ok, Pid1} = cets:start(d1, #{handle_down => DownFn}),
     {ok, Pid2} = cets:start(d2, #{}),
     ok = cets_join:join(lock1, #{table => [d1, d2]}, Pid1, Pid2),
@@ -780,10 +780,10 @@ unpause_if_pause_owner_crashes(_Config) ->
     T = pause_crashed,
     {ok, Pid} = cets:start(T, #{}),
     spawn_monitor(fun() ->
-        cets:pause(Pid),
-        Me ! pause_called,
-        error(wow)
-    end),
+                          cets:pause(Pid),
+                          Me ! pause_called,
+                          error(wow)
+                  end),
     receive
         pause_called -> ok
     after 5000 -> ct:fail(timeout)
@@ -1055,5 +1055,5 @@ set_join_ref(Pid, JoinRef) ->
 
 set_other_servers(Pid, Servers) ->
     sys:replace_state(Pid, fun(#{other_servers := _} = State) ->
-        State#{other_servers := Servers}
-    end).
+                                   State#{other_servers := Servers}
+                           end).

--- a/test/cets_test_wait.erl
+++ b/test/cets_test_wait.erl
@@ -15,24 +15,24 @@ wait_until(Fun, ExpectedValue) ->
 %% Example: wait_until(fun () -> ... end, SomeVal, #{time_left => timer:seconds(2)})
 wait_until(Fun, ExpectedValue, Opts) ->
     Defaults = #{
-        validator => fun(NewValue) -> ExpectedValue =:= NewValue end,
-        expected_value => ExpectedValue,
-        time_left => timer:seconds(5),
-        sleep_time => 100,
-        history => [],
-        name => timeout
-    },
+                 validator => fun(NewValue) -> ExpectedValue =:= NewValue end,
+                 expected_value => ExpectedValue,
+                 time_left => timer:seconds(5),
+                 sleep_time => 100,
+                 history => [],
+                 name => timeout
+                },
     do_wait_until(Fun, maps:merge(Defaults, Opts)).
 
 do_wait_until(
-    _Fun,
-    #{
-        expected_value := ExpectedValue,
-        time_left := TimeLeft,
-        history := History,
-        name := Name
-    } = Opts
-) when TimeLeft =< 0 ->
+  _Fun,
+  #{
+    expected_value := ExpectedValue,
+    time_left := TimeLeft,
+    history := History,
+    name := Name
+   } = Opts
+ ) when TimeLeft =< 0 ->
     error({Name, ExpectedValue, simplify_history(lists:reverse(History), 1), on_error(Opts)});
 do_wait_until(Fun, #{validator := Validator} = Opts) ->
     try Fun() of
@@ -59,16 +59,16 @@ simplify_history([], 1) ->
     [].
 
 wait_and_continue(
-    Fun,
-    FunResult,
-    #{
-        time_left := TimeLeft,
-        sleep_time := SleepTime,
-        history := History
-    } = Opts
-) ->
+  Fun,
+  FunResult,
+  #{
+    time_left := TimeLeft,
+    sleep_time := SleepTime,
+    history := History
+   } = Opts
+ ) ->
     timer:sleep(SleepTime),
     do_wait_until(Fun, Opts#{
-        time_left => TimeLeft - SleepTime,
-        history => [FunResult | History]
-    }).
+                             time_left => TimeLeft - SleepTime,
+                             history => [FunResult | History]
+                            }).


### PR DESCRIPTION
Tried https://github.com/fenollp/erlang-formatter

Requires Emacs, but runs it in background, so could still be usable on CI to code style check.

Do not merge.


It does weird stuff sometimes:
<img width="1218" alt="Screenshot 2023-08-04 at 16 18 56" src="https://github.com/esl/cets/assets/639796/df424282-9a86-4960-b981-c259378fabdb">
(comment run away). Maybe it just tries to follow the existing style and confused by Whatapp style (so, reformatting it manually and formatting it again would make a different result).
