### PR TITLE
Parallel tests

### DIFF
--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -4,6 +4,12 @@
 -compile([export_all, nowarn_export_all]).
 
 all() ->
+    [{group, cets}].
+
+groups() ->
+    [{cets, [parallel, {repeat_until_any_fail, 3}], cases()}].
+
+cases() ->
     [
         inserted_records_could_be_read_back,
         insert_many_with_one_record,
@@ -101,47 +107,47 @@ end_per_testcase(_, _Config) ->
     ok.
 
 inserted_records_could_be_read_back(_Config) ->
-    cets:start(ins1, #{}),
+    start_local(ins1, #{}),
     cets:insert(ins1, {alice, 32}),
     [{alice, 32}] = ets:lookup(ins1, alice).
 
 insert_many_with_one_record(_Config) ->
-    cets:start(ins1m, #{}),
+    start_local(ins1m, #{}),
     cets:insert_many(ins1m, [{alice, 32}]),
     [{alice, 32}] = ets:lookup(ins1m, alice).
 
 insert_many_with_two_records(_Config) ->
-    cets:start(ins2m, #{}),
+    start_local(ins2m, #{}),
     cets:insert_many(ins2m, [{alice, 32}, {bob, 55}]),
     [{alice, 32}, {bob, 55}] = ets:tab2list(ins2m).
 
 delete_works(_Config) ->
-    cets:start(del1, #{}),
+    start_local(del1, #{}),
     cets:insert(del1, {alice, 32}),
     cets:delete(del1, alice),
     [] = ets:lookup(del1, alice).
 
 delete_many_works(_Config) ->
-    cets:start(del1, #{}),
-    cets:insert(del1, {alice, 32}),
-    cets:delete_many(del1, [alice]),
-    [] = ets:lookup(del1, alice).
+    start_local(del2, #{}),
+    cets:insert(del2, {alice, 32}),
+    cets:delete_many(del2, [alice]),
+    [] = ets:lookup(del2, alice).
 
 join_works(_Config) ->
-    {ok, Pid1} = cets:start(join1tab, #{}),
-    {ok, Pid2} = cets:start(join2tab, #{}),
+    {ok, Pid1} = start_local(join1tab, #{}),
+    {ok, Pid2} = start_local(join2tab, #{}),
     ok = cets_join:join(join_lock1, #{}, Pid1, Pid2).
 
 inserted_records_could_be_read_back_from_replicated_table(_Config) ->
-    {ok, Pid1} = cets:start(ins1tab, #{}),
-    {ok, Pid2} = cets:start(ins2tab, #{}),
+    {ok, Pid1} = start_local(ins1tab, #{}),
+    {ok, Pid2} = start_local(ins2tab, #{}),
     ok = cets_join:join(join_lock1_ins, #{}, Pid1, Pid2),
     cets:insert(ins1tab, {alice, 32}),
     [{alice, 32}] = ets:lookup(ins2tab, alice).
 
 insert_new_works(_Config) ->
-    {ok, Pid1} = cets:start(newins1tab, #{}),
-    {ok, Pid2} = cets:start(newins2tab, #{}),
+    {ok, Pid1} = start_local(newins1tab, #{}),
+    {ok, Pid2} = start_local(newins2tab, #{}),
     ok = cets_join:join(join_lock1_insnew, #{}, Pid1, Pid2),
     true = cets:insert_new(Pid1, {alice, 32}),
     %% Duplicate found
@@ -150,15 +156,15 @@ insert_new_works(_Config) ->
     false = cets:insert_new(Pid2, {alice, 33}).
 
 insert_new_works_with_table_name(_Config) ->
-    {ok, Pid1} = cets:start(T1 = tabinsnew1, #{}),
-    {ok, Pid2} = cets:start(T2 = tabinsnew2, #{}),
+    {ok, Pid1} = start_local(T1 = tabinsnew1, #{}),
+    {ok, Pid2} = start_local(T2 = tabinsnew2, #{}),
     ok = cets_join:join(join_lock1_insnew2, #{}, Pid1, Pid2),
     true = cets:insert_new(T1, {alice, 32}),
     false = cets:insert_new(T2, {alice, 32}).
 
 insert_new_works_when_leader_is_back(_Config) ->
-    {ok, Pid1} = cets:start(newins1tab_back, #{}),
-    {ok, Pid2} = cets:start(newins2tab_back, #{}),
+    {ok, Pid1} = start_local(newins1tab_back, #{}),
+    {ok, Pid2} = start_local(newins2tab_back, #{}),
     ok = cets_join:join(join_lock1_insnew_back, #{}, Pid1, Pid2),
     Leader = cets:get_leader(Pid1),
     %% Highest Pid is the leader:
@@ -171,9 +177,9 @@ insert_new_works_when_leader_is_back(_Config) ->
     true = cets:insert_new(Pid1, {alice, 32}).
 
 insert_new_when_new_leader_has_joined(_Config) ->
-    {ok, Pid1} = cets:start(T1 = insert_new_tab4a, #{}),
-    {ok, Pid2} = cets:start(T2 = insert_new_tab4b, #{}),
-    {ok, Pid3} = cets:start(T3 = insert_new_tab4c, #{}),
+    {ok, Pid1} = start_local(T1 = insert_new_tab4a, #{}),
+    {ok, Pid2} = start_local(T2 = insert_new_tab4b, #{}),
+    {ok, Pid3} = start_local(T3 = insert_new_tab4c, #{}),
     %% Join first network segment
     ok = cets_join:join(insert_new_lock4, #{}, Pid1, Pid2),
     %% Pause insert into the first segment
@@ -191,9 +197,9 @@ insert_new_when_new_leader_has_joined(_Config) ->
 
 %% Checks that the handle_wrong_leader is called
 insert_new_when_new_leader_has_joined_duplicate(_Config) ->
-    {ok, Pid1} = cets:start(T1 = insert_new_tab5a, #{}),
-    {ok, Pid2} = cets:start(T2 = insert_new_tab5b, #{}),
-    {ok, Pid3} = cets:start(T3 = insert_new_tab5c, #{}),
+    {ok, Pid1} = start_local(T1 = insert_new_tab5a, #{}),
+    {ok, Pid2} = start_local(T2 = insert_new_tab5b, #{}),
+    {ok, Pid3} = start_local(T3 = insert_new_tab5c, #{}),
     %% Join first network segment
     ok = cets_join:join(join_lock1_insnew_back4, #{}, Pid1, Pid2),
     %% Put record into the second network segment
@@ -214,8 +220,8 @@ insert_new_when_new_leader_has_joined_duplicate(_Config) ->
 %% Rare case when tables contain different data
 %% (the developer should try to avoid the manual removal of data if possible)
 insert_new_when_inconsistent(_Config) ->
-    {ok, Pid1} = cets:start(T1 = insert_new_lock6a, #{}),
-    {ok, Pid2} = cets:start(T2 = insert_new_lock6b, #{}),
+    {ok, Pid1} = start_local(T1 = insert_new_lock6a, #{}),
+    {ok, Pid2} = start_local(T2 = insert_new_lock6b, #{}),
     ok = cets_join:join(insert_new_lock6, #{}, Pid1, Pid2),
     true = cets:insert_new(Pid1, {alice, 33}),
     true = cets:insert_new(Pid2, {bob, 40}),
@@ -230,8 +236,8 @@ insert_new_when_inconsistent(_Config) ->
 insert_new_is_retried_when_leader_is_reelected(_Config) ->
     Me = self(),
     F = fun(X) -> Me ! {wrong_leader_detected, X} end,
-    {ok, Pid1} = cets:start(newins1tab_back2, #{}),
-    {ok, Pid2} = cets:start(newins2tab_back2, #{handle_wrong_leader => F}),
+    {ok, Pid1} = start_local(newins1tab_back2, #{}),
+    {ok, Pid2} = start_local(newins2tab_back2, #{handle_wrong_leader => F}),
     ok = cets_join:join(join_lock1_insnew_back2, #{}, Pid1, Pid2),
     Leader = cets:get_leader(Pid1),
     %% Ask process to reject all the leader operations
@@ -263,8 +269,8 @@ insert_new_is_retried_when_leader_is_reelected(_Config) ->
 %% - call insert_new one more time
 %% - read the data back using ets:lookup to ensure it is your record written
 insert_new_fails_if_the_leader_dies(_Config) ->
-    {ok, Pid1} = cets:start(newins1tab_back3, #{}),
-    {ok, Pid2} = cets:start(newins2tab_back3, #{}),
+    {ok, Pid1} = start_local(newins1tab_back3, #{}),
+    {ok, Pid2} = start_local(newins2tab_back3, #{}),
     ok = cets_join:join(join_lock1_insnew_back3, #{}, Pid1, Pid2),
     cets:pause(Pid2),
     spawn(fun() ->
@@ -290,8 +296,8 @@ insert_new_fails_if_the_local_server_is_dead(_Config) ->
     end.
 
 leader_is_the_same_in_metadata_after_join(_Config) ->
-    {ok, Pid1} = cets:start(T1 = check_lead1, #{}),
-    {ok, Pid2} = cets:start(T2 = check_lead2, #{}),
+    {ok, Pid1} = start_local(T1 = check_lead1, #{}),
+    {ok, Pid2} = start_local(T2 = check_lead2, #{}),
     ok = cets_join:join(check_lead_lock, #{}, Pid1, Pid2),
     Leader = cets:get_leader(Pid1),
     Leader = cets:get_leader(Pid2),
@@ -299,8 +305,8 @@ leader_is_the_same_in_metadata_after_join(_Config) ->
     Leader = cets_metadata:get(T2, leader).
 
 join_works_with_existing_data(_Config) ->
-    {ok, Pid1} = cets:start(ex1tab, #{}),
-    {ok, Pid2} = cets:start(ex2tab, #{}),
+    {ok, Pid1} = start_local(ex1tab, #{}),
+    {ok, Pid2} = start_local(ex2tab, #{}),
     cets:insert(ex1tab, {alice, 32}),
     %% Join will copy and merge existing tables
     ok = cets_join:join(join_lock1_ex, #{}, Pid1, Pid2),
@@ -310,8 +316,8 @@ join_works_with_existing_data(_Config) ->
 %% Usually, inserting with the same key from two different nodes is not possible
 %% (because the node-name is a part of the key).
 join_works_with_existing_data_with_conflicts(_Config) ->
-    {ok, Pid1} = cets:start(con1tab, #{}),
-    {ok, Pid2} = cets:start(con2tab, #{}),
+    {ok, Pid1} = start_local(con1tab, #{}),
+    {ok, Pid2} = start_local(con2tab, #{}),
     cets:insert(con1tab, {alice, 32}),
     cets:insert(con2tab, {alice, 33}),
     %% Join will copy and merge existing tables
@@ -322,8 +328,8 @@ join_works_with_existing_data_with_conflicts(_Config) ->
 
 join_works_with_existing_data_with_conflicts_and_defined_conflict_handler(_Config) ->
     Opts = #{handle_conflict => fun resolve_highest/2},
-    {ok, Pid1} = cets:start(fn_con1tab, Opts),
-    {ok, Pid2} = cets:start(fn_con2tab, Opts),
+    {ok, Pid1} = start_local(fn_con1tab, Opts),
+    {ok, Pid2} = start_local(fn_con2tab, Opts),
     cets:insert(fn_con1tab, {alice, 32}),
     cets:insert(fn_con2tab, {alice, 33}),
     %% Join will copy and merge existing tables
@@ -335,9 +341,9 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler(_Confi
 join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_more_keys(_Config) ->
     %% Deeper testing of cets_join:apply_resolver function
     Opts = #{handle_conflict => fun resolve_highest/2},
-    {ok, Pid1} = cets:start(T1 = fn2_con1tab, Opts),
-    {ok, Pid2} = cets:start(T2 = fn2_con2tab, Opts),
-    {ok, Pid3} = cets:start(T3 = fn2_con3tab, Opts),
+    {ok, Pid1} = start_local(T1 = fn2_con1tab, Opts),
+    {ok, Pid2} = start_local(T2 = fn2_con2tab, Opts),
+    {ok, Pid3} = start_local(T3 = fn2_con3tab, Opts),
     cets:insert_many(T1, [{alice, 32}, {bob, 10}, {michal, 40}]),
     cets:insert_many(T2, [{alice, 33}, {kate, 3}, {michal, 2}]),
     %% Join will copy and merge existing tables
@@ -354,8 +360,8 @@ join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_mo
 %% Test with records (which require keypos = 2 option)
 join_works_with_existing_data_with_conflicts_and_defined_conflict_handler_and_keypos2(_Config) ->
     Opts = #{handle_conflict => fun resolve_user_conflict/2, keypos => 2},
-    {ok, Pid1} = cets:start(T1 = keypos2_tab1, Opts),
-    {ok, Pid2} = cets:start(T2 = keypos2_tab2, Opts),
+    {ok, Pid1} = start_local(T1 = keypos2_tab1, Opts),
+    {ok, Pid2} = start_local(T2 = keypos2_tab2, Opts),
     cets:insert(T1, #user{name = alice, age = 30, updated = erlang:system_time()}),
     cets:insert(T2, #user{name = alice, age = 25, updated = erlang:system_time()}),
     %% Join will copy and merge existing tables
@@ -380,7 +386,7 @@ bag_with_conflict_handler_not_allowed(_Config) ->
         cets:start(ex1tab, #{handle_conflict => fun resolve_highest/2, type => bag}).
 
 join_with_the_same_pid(_Config) ->
-    {ok, Pid} = cets:start(joinsame, #{}),
+    {ok, Pid} = start_local(joinsame, #{}),
     %% Just insert something into a table to check later the size
     cets:insert(joinsame, {1, 1}),
     link(Pid),
@@ -390,15 +396,15 @@ join_with_the_same_pid(_Config) ->
     #{nodes := Nodes, size := 1} = cets:info(Pid).
 
 join_ref_is_same_after_join(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}),
     #{join_ref := JoinRef} = cets:info(Pid1),
     #{join_ref := JoinRef} = cets:info(Pid2).
 
 join_fails_because_server_process_not_found(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     F = fun
         (join_start) ->
             exit(Pid1, sim_error);
@@ -409,8 +415,8 @@ join_fails_because_server_process_not_found(Config) ->
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{checkpoint_handler => F}).
 
 join_fails_because_server_process_not_found_before_get_pids(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     F = fun
         (before_get_pids) ->
             exit(Pid1, sim_error);
@@ -425,8 +431,8 @@ join_fails_before_send_dump(Config) ->
     DownFn = fun(#{remote_pid := RemotePid, table := _Tab}) ->
         Me ! {down_called, self(), RemotePid}
     end,
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{handle_down => DownFn}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{handle_down => DownFn}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     cets:insert(Pid1, {1}),
     cets:insert(Pid2, {2}),
     F = fun
@@ -456,8 +462,8 @@ join_fails_before_send_dump(Config) ->
 %% Checks that remote ops are dropped if join_ref does not match in the state and in remote_op message
 join_fails_before_send_dump_and_there_are_pending_remote_ops(Config) ->
     Me = self(),
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     F = fun
         ({before_send_dump, P}) when Pid1 =:= P ->
             Me ! before_send_dump_called_for_pid1;
@@ -491,8 +497,8 @@ send_dump_fails_during_join_because_receiver_exits(Config) ->
     DownFn = fun(#{remote_pid := RemotePid, table := _Tab}) ->
         Me ! {down_called, self(), RemotePid}
     end,
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{handle_down => DownFn}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{handle_down => DownFn}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     F = fun
         ({before_send_dump, P}) when P =:= Pid1 ->
             %% Kill Pid2 process.
@@ -516,9 +522,9 @@ send_dump_fails_during_join_because_receiver_exits(Config) ->
 
 join_fails_in_check_fully_connected(Config) ->
     Me = self(),
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
-    {ok, Pid3} = cets:start(make_name(Config, 3), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
+    {ok, Pid3} = start_local(make_name(Config, 3), #{}),
     %% Pid2 and Pid3 are connected
     ok = cets_join:join(lock_name(Config), #{}, Pid2, Pid3, #{}),
     [Pid3] = cets:other_pids(Pid2),
@@ -538,9 +544,9 @@ join_fails_in_check_fully_connected(Config) ->
     receive_message(before_check_fully_connected_called).
 
 join_fails_because_join_refs_do_not_match_for_nodes_in_segment(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
-    {ok, Pid3} = cets:start(make_name(Config, 3), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
+    {ok, Pid3} = start_local(make_name(Config, 3), #{}),
     %% Pid2 and Pid3 are connected
     %% But for some reason Pid3 has a different join_ref
     %% (probably could happen if it still haven't checked other nodes after a join)
@@ -550,9 +556,9 @@ join_fails_because_join_refs_do_not_match_for_nodes_in_segment(Config) ->
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}).
 
 join_fails_because_pids_do_not_match_for_nodes_in_segment(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
-    {ok, Pid3} = cets:start(make_name(Config, 3), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
+    {ok, Pid3} = start_local(make_name(Config, 3), #{}),
     %% Pid2 and Pid3 are connected
     %% But for some reason Pid3 has a different other_nodes list
     %% (probably could happen if it still haven't checked other nodes after a join)
@@ -562,17 +568,17 @@ join_fails_because_pids_do_not_match_for_nodes_in_segment(Config) ->
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}).
 
 join_fails_because_servers_overlap(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
-    {ok, Pid3} = cets:start(make_name(Config, 3), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
+    {ok, Pid3} = start_local(make_name(Config, 3), #{}),
     set_other_servers(Pid1, [Pid3]),
     set_other_servers(Pid2, [Pid3]),
     {error, check_do_not_overlap_failed} =
         cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}).
 
 remote_ops_are_ignored_if_join_ref_does_not_match(Config) ->
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}),
     #{join_ref := JoinRef} = cets:info(Pid1),
     set_join_ref(Pid1, make_ref()),
@@ -584,8 +590,8 @@ remote_ops_are_ignored_if_join_ref_does_not_match(Config) ->
 
 join_retried_if_lock_is_busy(Config) ->
     Me = self(),
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     Lock = lock_name(Config),
     SleepyF = fun
         (join_start) ->
@@ -611,8 +617,8 @@ join_retried_if_lock_is_busy(Config) ->
 
 send_dump_contains_already_added_servers(Config) ->
     %% Check that even if we have already added server in send_dump, nothing crashes
-    {ok, Pid1} = cets:start(make_name(Config, 1), #{}),
-    {ok, Pid2} = cets:start(make_name(Config, 2), #{}),
+    {ok, Pid1} = start_local(make_name(Config, 1), #{}),
+    {ok, Pid2} = start_local(make_name(Config, 2), #{}),
     ok = cets_join:join(lock_name(Config), #{}, Pid1, Pid2, #{}),
     PauseRef = cets:pause(Pid1),
     %% That should be called by cets_join module
@@ -708,8 +714,8 @@ test_multinode_auto_discovery(Config) ->
     ok.
 
 test_locally(_Config) ->
-    {ok, Pid1} = cets:start(t1, #{}),
-    {ok, Pid2} = cets:start(t2, #{}),
+    {ok, Pid1} = start_local(t1, #{}),
+    {ok, Pid2} = start_local(t2, #{}),
     ok = cets_join:join(lock1, #{table => [t1, t2]}, Pid1, Pid2),
     cets:insert(t1, {1}),
     cets:insert(t1, {1}),
@@ -722,8 +728,8 @@ handle_down_is_called(_Config) ->
     DownFn = fun(#{remote_pid := _RemotePid, table := _Tab}) ->
         Parent ! down_called
     end,
-    {ok, Pid1} = cets:start(d1, #{handle_down => DownFn}),
-    {ok, Pid2} = cets:start(d2, #{}),
+    {ok, Pid1} = start_local(d1, #{handle_down => DownFn}),
+    {ok, Pid2} = start_local(d2, #{}),
     ok = cets_join:join(lock1, #{table => [d1, d2]}, Pid1, Pid2),
     exit(Pid2, oops),
     receive
@@ -733,7 +739,7 @@ handle_down_is_called(_Config) ->
 
 events_are_applied_in_the_correct_order_after_unpause(_Config) ->
     T = t4,
-    {ok, Pid} = cets:start(T, #{}),
+    {ok, Pid} = start_local(T, #{}),
     PauseMon = cets:pause(Pid),
     R1 = cets:insert_request(T, {1}),
     R2 = cets:delete_request(T, 1),
@@ -751,7 +757,7 @@ events_are_applied_in_the_correct_order_after_unpause(_Config) ->
 
 pause_multiple_times(_Config) ->
     T = t5,
-    {ok, Pid} = cets:start(T, #{}),
+    {ok, Pid} = start_local(T, #{}),
     PauseMon1 = cets:pause(Pid),
     PauseMon2 = cets:pause(Pid),
     Ref1 = cets:insert_request(Pid, {1}),
@@ -770,7 +776,7 @@ pause_multiple_times(_Config) ->
 
 unpause_twice(_Config) ->
     T = t6,
-    {ok, Pid} = cets:start(T, #{}),
+    {ok, Pid} = start_local(T, #{}),
     PauseMon = cets:pause(Pid),
     ok = cets:unpause(Pid, PauseMon),
     {error, unknown_pause_monitor} = cets:unpause(Pid, PauseMon).
@@ -778,7 +784,7 @@ unpause_twice(_Config) ->
 unpause_if_pause_owner_crashes(_Config) ->
     Me = self(),
     T = pause_crashed,
-    {ok, Pid} = cets:start(T, #{}),
+    {ok, Pid} = start_local(T, #{}),
     spawn_monitor(fun() ->
         cets:pause(Pid),
         Me ! pause_called,
@@ -792,8 +798,8 @@ unpause_if_pause_owner_crashes(_Config) ->
     ok = cets:insert(Pid, {1}).
 
 write_returns_if_remote_server_crashes(_Config) ->
-    {ok, Pid1} = cets:start(c1, #{}),
-    {ok, Pid2} = cets:start(c2, #{}),
+    {ok, Pid1} = start_local(c1, #{}),
+    {ok, Pid2} = start_local(c2, #{}),
     ok = cets_join:join(lock1, #{table => [c1, c2]}, Pid1, Pid2),
     sys:suspend(Pid2),
     R = cets:insert_request(c1, {1}),
@@ -801,7 +807,7 @@ write_returns_if_remote_server_crashes(_Config) ->
     {reply, ok} = cets:wait_response(R, 5000).
 
 ack_process_stops_correctly(_Config) ->
-    {ok, Pid} = cets:start(ack_stops, #{}),
+    {ok, Pid} = start_local(ack_stops, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     AckMon = monitor(process, AckPid),
     cets:stop(Pid),
@@ -811,8 +817,8 @@ ack_process_stops_correctly(_Config) ->
     end.
 
 ack_process_handles_unknown_remote_server(_Config) ->
-    {ok, Pid1} = cets:start(ack_unkn1, #{}),
-    {ok, Pid2} = cets:start(ack_unkn2, #{}),
+    {ok, Pid1} = start_local(ack_unkn1, #{}),
+    {ok, Pid2} = start_local(ack_unkn2, #{}),
     ok = cets_join:join(lock_ack, #{}, Pid1, Pid2),
     sys:suspend(Pid2),
     #{ack_pid := AckPid} = cets:info(Pid1),
@@ -830,8 +836,8 @@ ack_process_handles_unknown_remote_server(_Config) ->
     {reply, ok} = cets:wait_response(R, 5000).
 
 ack_process_handles_unknown_from(_Config) ->
-    {ok, Pid1} = cets:start(ack_unkn_from1, #{}),
-    {ok, Pid2} = cets:start(ack_unkn_from2, #{}),
+    {ok, Pid1} = start_local(ack_unkn_from1, #{}),
+    {ok, Pid2} = start_local(ack_unkn_from2, #{}),
     ok = cets_join:join(lock_ack, #{}, Pid1, Pid2),
     #{ack_pid := AckPid} = cets:info(Pid1),
     R = cets:insert_request(Pid1, {1}),
@@ -841,7 +847,7 @@ ack_process_handles_unknown_from(_Config) ->
     {reply, ok} = cets:wait_response(R, 5000).
 
 ack_calling_add_when_server_list_is_empty_is_not_allowed(_Config) ->
-    {ok, Pid} = cets:start(add_fails, #{}),
+    {ok, Pid} = start_local(add_fails, #{}),
     Mon = monitor(process, Pid),
     #{ack_pid := AckPid} = cets:info(Pid),
     FakeFrom = {self(), make_ref()},
@@ -856,18 +862,18 @@ ack_calling_add_when_server_list_is_empty_is_not_allowed(_Config) ->
     end.
 
 sync_using_name_works(_Config) ->
-    {ok, _Pid1} = cets:start(c4, #{}),
+    {ok, _Pid1} = start_local(c4, #{}),
     cets:sync(c4).
 
 insert_many_request(_Config) ->
-    {ok, Pid} = cets:start(c5, #{}),
+    {ok, Pid} = start_local(c5, #{}),
     R = cets:insert_many_request(Pid, [{a}, {b}]),
     {reply, ok} = cets:wait_response(R, 5000),
     [{a}, {b}] = ets:tab2list(c5).
 
 insert_into_bag(_Config) ->
     T = b1,
-    {ok, _Pid} = cets:start(T, #{type => bag}),
+    {ok, _Pid} = start_local(T, #{type => bag}),
     cets:insert(T, {1, 1}),
     cets:insert(T, {1, 1}),
     cets:insert(T, {1, 2}),
@@ -875,21 +881,21 @@ insert_into_bag(_Config) ->
 
 delete_from_bag(_Config) ->
     T = b2,
-    {ok, _Pid} = cets:start(T, #{type => bag}),
+    {ok, _Pid} = start_local(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}]),
     cets:delete_object(T, {1, 2}),
     [{1, 1}] = cets:dump(T).
 
 delete_many_from_bag(_Config) ->
     T = b3,
-    {ok, _Pid} = cets:start(T, #{type => bag}),
+    {ok, _Pid} = start_local(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}, {1, 3}, {1, 5}, {2, 3}]),
     cets:delete_objects(T, [{1, 2}, {1, 5}, {1, 4}]),
     [{1, 1}, {1, 3}, {2, 3}] = lists:sort(cets:dump(T)).
 
 delete_request_from_bag(_Config) ->
     T = b4,
-    {ok, _Pid} = cets:start(T, #{type => bag}),
+    {ok, _Pid} = start_local(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}]),
     R = cets:delete_object_request(T, {1, 2}),
     {reply, ok} = cets:wait_response(R, 5000),
@@ -897,22 +903,22 @@ delete_request_from_bag(_Config) ->
 
 delete_request_many_from_bag(_Config) ->
     T = b5,
-    {ok, _Pid} = cets:start(T, #{type => bag}),
+    {ok, _Pid} = start_local(T, #{type => bag}),
     cets:insert_many(T, [{1, 1}, {1, 2}, {1, 3}]),
     R = cets:delete_objects_request(T, [{1, 1}, {1, 3}]),
     {reply, ok} = cets:wait_response(R, 5000),
     [{1, 2}] = cets:dump(T).
 
 insert_into_bag_is_replicated(_Config) ->
-    {ok, Pid1} = cets:start(b6a, #{type => bag}),
-    {ok, Pid2} = cets:start(T2 = b6b, #{type => bag}),
+    {ok, Pid1} = start_local(b6a, #{type => bag}),
+    {ok, Pid2} = start_local(T2 = b6b, #{type => bag}),
     ok = cets_join:join(join_lock_b6, #{}, Pid1, Pid2),
     cets:insert(Pid1, {1, 1}),
     [{1, 1}] = cets:dump(T2).
 
 insert_into_keypos_table(_Config) ->
     T = kp1,
-    {ok, _Pid} = cets:start(T, #{keypos => 2}),
+    {ok, _Pid} = start_local(T, #{keypos => 2}),
     cets:insert(T, {rec, 1}),
     cets:insert(T, {rec, 2}),
     [{rec, 1}] = lists:sort(ets:lookup(T, 1)),
@@ -920,60 +926,60 @@ insert_into_keypos_table(_Config) ->
 
 table_name_works(_Config) ->
     T = tabnamecheck,
-    {ok, Pid} = cets:start(T, #{}),
+    {ok, Pid} = start_local(T, #{}),
     {ok, T} = cets:table_name(T),
     {ok, T} = cets:table_name(Pid),
     #{table := T} = cets:info(Pid).
 
 info_contains_opts(_Config) ->
-    {ok, Pid} = cets:start(info_contains_opts, #{type => bag}),
+    {ok, Pid} = start_local(info_contains_opts, #{type => bag}),
     #{opts := #{type := bag}} = cets:info(Pid).
 
 %% Cases to improve code coverage
 
 unknown_down_message_is_ignored(_Config) ->
-    {ok, Pid} = cets:start(rand_down_msg, #{}),
+    {ok, Pid} = start_local(rand_down_msg, #{}),
     RandPid = spawn(fun() -> ok end),
     Pid ! {'DOWN', make_ref(), process, RandPid, oops},
     still_works(Pid).
 
 unknown_message_is_ignored(_Config) ->
-    {ok, Pid} = cets:start(unkn_msg, #{}),
+    {ok, Pid} = start_local(unkn_msg, #{}),
     Pid ! oops,
     still_works(Pid).
 
 unknown_cast_message_is_ignored(_Config) ->
-    {ok, Pid} = cets:start(unkn_cast_msg, #{}),
+    {ok, Pid} = start_local(unkn_cast_msg, #{}),
     gen_server:cast(Pid, oops),
     still_works(Pid).
 
 unknown_message_is_ignored_in_ack_process(_Config) ->
-    {ok, Pid} = cets:start(ack_unkn_msg, #{}),
+    {ok, Pid} = start_local(ack_unkn_msg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     AckPid ! oops,
     still_works(Pid).
 
 unknown_cast_message_is_ignored_in_ack_process(_Config) ->
-    {ok, Pid} = cets:start(ack_unkn_cast_msg, #{}),
+    {ok, Pid} = start_local(ack_unkn_cast_msg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     gen_server:cast(AckPid, oops),
     still_works(Pid).
 
 unknown_call_returns_error_from_ack_process(_Config) ->
-    {ok, Pid} = cets:start(ack_unkn_call_msg, #{}),
+    {ok, Pid} = start_local(ack_unkn_call_msg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     {error, unexpected_call} = gen_server:call(AckPid, oops),
     still_works(Pid).
 
 code_change_returns_ok(_Config) ->
-    {ok, Pid} = cets:start(ack_code_chg, #{}),
+    {ok, Pid} = start_local(ack_code_chg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     sys:suspend(AckPid),
     ok = sys:change_code(AckPid, cets, v2, []),
     sys:resume(AckPid).
 
 code_change_returns_ok_for_ack(_Config) ->
-    {ok, Pid} = cets:start(code_chg, #{}),
+    {ok, Pid} = start_local(code_chg, #{}),
     #{ack_pid := AckPid} = cets:info(Pid),
     sys:suspend(AckPid),
     ok = sys:change_code(AckPid, cets_ack, v2, []),
@@ -994,8 +1000,25 @@ still_works(Pid) ->
     ok = cets:insert(Pid, {1}),
     {ok, [{1}]} = cets:remote_dump(Pid).
 
+start_local(Name, Opts) ->
+    {ok, Pid} = cets:start(Name, Opts),
+    schedule_cleanup(Pid),
+    {ok, Pid}.
+
+schedule_cleanup(Pid) ->
+    Me = self(),
+    spawn(fun() ->
+        Ref = erlang:monitor(process, Me),
+        receive
+            {'DOWN', Ref, process, Me, _} ->
+                cets:stop(Pid)
+        end
+    end).
+
 start(Node, Tab) ->
-    rpc(Node, cets, start, [Tab, #{}]).
+    {ok, Pid} = rpc(Node, cets, start, [Tab, #{}]),
+    schedule_cleanup(Pid),
+    {ok, Pid}.
 
 insert(Node, Tab, Rec) ->
     rpc(Node, cets, insert, [Tab, Rec]).


### PR DESCRIPTION
Changes:
- parallel tests.
- stop CETS servers on exit.
- repeat 3 times.
- use helpers to name tables.
- use helpers to spawn common configurations (i.e. 2 joined nodes).

- NO new tests.
- NO modification to the main code.

Motivation:
- Naming servers is hard :)
- Code looked different in each testcase (because of manual naming)