### PR TITLE
Use rebar3 aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run dialyzer
       run: rebar3 dialyzer
 
@@ -50,8 +48,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Compile
-      run: rebar3 compile
     - name: Run xref
       run: rebar3 xref
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Compile
-      run: rebar3 compile
+      run: rebar3 as test compile
     - name: Run tests
       run: rebar3 cover_test
     - name: Send test coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Compile
       run: rebar3 as test compile
     - name: Run tests
-      run: rebar3 cover_test
+      run: rebar3 cover_tests
     - name: Send test coverage report
       run: rebar3 as test codecov analyze
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Compile
       run: rebar3 compile
     - name: Run tests
-      run: rebar3 as test ct --sname=ct1 --cover
+      run: rebar3 cover_test
     - name: Send test coverage report
       run: rebar3 as test codecov analyze
     - name: Upload coverage reports to Codecov
@@ -64,4 +64,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run erlfmt
-      run: rebar3 fmt --check
+      run: rebar3 format_check

--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,7 @@
     {all, [
         format,
         run_tests,
+        xref,
         dialyzer
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,10 +8,30 @@
     ]}
 ]}.
 
-%% Enables "rebar3 fmt" command
-{project_plugins, [erlfmt]}.
+{alias, [
+    {format, [
+        {do, "default as format fmt -w"}
+    ]},
+    {format_check, [
+        {do, "default as format fmt -c"}
+    ]},
+    {run_test, [
+        {ct, "--sname=ct1"}
+    ]},
+    {cover_test, [
+        {ct, "--sname=ct1 --cover"}
+    ]},
+    {all, [
+        format,
+        run_test,
+        dialyzer
+    ]}
+]}.
 
 {profiles, [
+    {format, [
+        {plugins, [erlfmt]}
+    ]},
     {test, [
         {plugins, [
             {rebar3_codecov, "0.4.0"}

--- a/rebar.config
+++ b/rebar.config
@@ -15,15 +15,15 @@
     {format_check, [
         {do, "default as format fmt -c"}
     ]},
-    {run_test, [
+    {run_tests, [
         {ct, "--sname=ct1"}
     ]},
-    {cover_test, [
+    {cover_tests, [
         {ct, "--sname=ct1 --cover"}
     ]},
     {all, [
         format,
-        run_test,
+        run_tests,
         dialyzer
     ]}
 ]}.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-rebar3 ct --sname=ct1


### PR DESCRIPTION
I've tried to use makefiles to automate running 3 commands I always do, but @NelsonVides suggested to use rebar3 aliases.

- Added `rebar3 all` that runs all the checks before making a commit or PR.
- Move `rebar3 fmt` into a profile, because it takes a bit of time to build formatting tool and its deps (i.e. faster CI for tasks like dialyzer and build).
- Remove my favourite `run_test.sh`

PS: syntax for commands with aliases is weird (i.e. do...default).