### PR TITLE
Fix logger cover

### DIFF
--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -72,14 +72,13 @@ send_leader_op(Server, Op, Backoff) ->
     Res = maybe_sync_operation(Leader, {leader_op, Op}),
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
-            Log = #{
+            ?LOG_WARNING(#{
                 what => wrong_leader,
                 server => Server,
                 operation => Op,
                 called_leader => Leader,
                 expected_leader => ExpectedLeader
-            },
-            ?LOG_WARNING(Log),
+            }),
             %% This could happen if a new node joins the cluster.
             %% So, a simple retry should help.
             case Backoff of

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -199,13 +199,12 @@ check_do_not_overlap(LocPids, RemPids) ->
         [] ->
             ok;
         Overlap ->
-            Log = #{
+            ?LOG_ERROR(#{
                 what => check_do_not_overlap_failed,
                 local_servers => LocPids,
                 remote_servers => RemPids,
                 overlapped_servers => Overlap
-            },
-            ?LOG_ERROR(Log),
+            }),
             error(check_do_not_overlap_failed)
     end.
 
@@ -218,12 +217,11 @@ check_fully_connected(Pids) ->
         true ->
             check_same_join_ref(Pids);
         false ->
-            Log = #{
+            ?LOG_ERROR(#{
                 what => check_fully_connected_failed,
                 expected_pids => Pids,
                 server_lists => Lists
-            },
-            ?LOG_ERROR(Log),
+            }),
             error(check_fully_connected_failed)
     end.
 
@@ -239,11 +237,10 @@ check_same_join_ref(Pids) ->
         [_] ->
             ok;
         _ ->
-            Log = #{
+            ?LOG_ERROR(#{
                 what => check_same_join_ref_failed,
                 refs => lists:zip(Pids, Refs)
-            },
-            ?LOG_ERROR(Log),
+            }),
             error(check_same_join_ref_failed)
     end.
 


### PR DESCRIPTION
The PR addresses MIM-2010:
- Multiline logging calls report one line as not covered by tests. See diff for the example of such calls.

Changes:
- Undo the changes introduced https://github.com/esl/cets/pull/12 - i.e. `Log = #{...}, ?LOG_ERROR(Log)` workaround.
- Run tests with logging disabled instead (additionally to the regular run).

More info about what it does https://github.com/erlang/otp/issues/7531