### PR TITLE
Improved discovery backend

### DIFF
--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -317,10 +317,10 @@ choose_retry_type(_) ->
 %% Returns timeout in milliseconds to retry calling the get_nodes function.
 %% get_nodes is called after add_table without waiting.
 %% It is also would be retried without waiting if should_retry_get_nodes set to true.
--spec retry_type_to_timeout(retry_type()) -> 5000 | 1000 | 180000.
-retry_type_to_timeout(initial) -> 5000;
-retry_type_to_timeout(after_error) -> 1000;
-retry_type_to_timeout(regular) -> 180000.
+-spec retry_type_to_timeout(retry_type()) -> non_neg_integer().
+retry_type_to_timeout(initial) -> timer:seconds(5);
+retry_type_to_timeout(after_error) -> timer:seconds(1);
+retry_type_to_timeout(regular) -> timer:minutes(5).
 
 -spec cancel_old_timer(state()) -> ok.
 cancel_old_timer(#{timer_ref := OldRef}) when is_reference(OldRef) ->

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -128,7 +128,7 @@ init(Opts) ->
     %% Changes phase from initial to regular (affects the check interval)
     erlang:send_after(timer:minutes(5), self(), enter_regular_phase),
     {ok, #{
-        phase => inital,
+        phase => initial,
         results => [],
         nodes => [],
         unavailable_nodes => [],

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -80,6 +80,7 @@
 -type opts() :: #{name := atom(), _ := _}.
 -type start_result() :: {ok, pid()} | {error, term()}.
 -type server() :: pid() | atom().
+-type system_info() :: map().
 
 -callback init(map()) -> backend_state().
 -callback get_nodes(backend_state()) -> {get_nodes_result(), backend_state()}.
@@ -115,7 +116,7 @@ info(Server) ->
     {ok, Tables} = get_tables(Server),
     [cets:info(Tab) || Tab <- Tables].
 
--spec system_info(server()) -> map().
+-spec system_info(server()) -> system_info().
 system_info(Server) ->
     gen_server:call(Server, system_info).
 
@@ -411,8 +412,10 @@ verify_tried_joining(State = #{nodes := Nodes, tables := Tables}) ->
         _ -> [{waiting_for_join_result, Missing}]
     end.
 
+-spec has_join_result_for(Node :: node(), Table :: atom(), state()) -> boolean().
 has_join_result_for(Node, Table, #{results := Results}) ->
     [] =/= [R || R = #{node := N, table := T} <- Results, N =:= Node, T =:= Table].
 
+-spec handle_system_info(state()) -> system_info().
 handle_system_info(State) ->
     State#{verify_ready => verify_ready(State)}.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -253,7 +253,7 @@ try_joining(State = #{join_status := not_running, nodes := Nodes, tables := Tabl
     AvailableNodes = nodes(),
     spawn_link(fun() ->
         %% We only care about connected nodes here
-        %% We do not wanna try to connect here - we do it in ping_not_connected_nodes/1
+        %% We do not want to try to connect here - we do it in ping_not_connected_nodes/1
         Results = [
             do_join(Tab, Node)
          || Node <- Nodes, lists:member(Node, AvailableNodes), Tab <- Tables

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -15,7 +15,8 @@
 %%   - dist_auto_connect=never
 %%   - connect_all
 %%   - prevent_overlapping_partitions
-%%   These flags change the way the discovery logic behaves.
+%% These flags change the way the discovery logic behaves.
+%% Also the module would not try to connect to the hidden nodes.
 %%
 %% Retry logic considerations:
 %% - Backend:get_nodes/1 could return an error during startup, so we have to retry fast.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -156,7 +156,7 @@ handle_cast({add_table, Table}, State = #{tables := Tables}) ->
             {noreply, State};
         false ->
             self() ! check,
-            State2 = State#{tables := [Table | Tables]},
+            State2 = State#{tables := ordsets:add_element(Table, Tables)},
             {noreply, State2}
     end;
 handle_cast(Msg, State) ->
@@ -243,7 +243,7 @@ try_joining(State = #{join_status := not_running, nodes := Nodes, tables := Tabl
 -spec handle_joining_finished(list(), state()) -> state().
 handle_joining_finished(Results, State = #{should_retry_join := Retry}) ->
     report_results(Results, State),
-    State2 = trigger_verify_ready(State#{results := Results}),
+    State2 = trigger_verify_ready(State#{results := Results, join_status := not_running}),
     case Retry of
         true ->
             try_joining(State2);

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -201,8 +201,8 @@ check_do_not_overlap(LocPids, RemPids) ->
         Overlap ->
             ?LOG_ERROR(#{
                 what => check_do_not_overlap_failed,
-                local_servers => LocPids,
-                remote_servers => RemPids,
+                local_servers => LocSet,
+                remote_servers => RemSet,
                 overlapped_servers => Overlap
             }),
             error(check_do_not_overlap_failed)

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -182,27 +182,27 @@ apply_resolver_for_sorted(
 apply_resolver_for_sorted(LocalDump, RemoteDump, _F, _Pos, LocalAcc, RemoteAcc) ->
     {lists:reverse(LocalAcc, LocalDump), lists:reverse(RemoteAcc, RemoteDump)}.
 
+-spec get_pids(server_pid()) -> cets:servers().
 get_pids(Pid) ->
-    [Pid | cets:other_pids(Pid)].
+    ordsets:add_element(Pid, cets:other_pids(Pid)).
 
+-spec check_pids(cets:servers(), cets:servers(), join_opts()) -> ok.
 check_pids(LocPids, RemPids, JoinOpts) ->
     check_do_not_overlap(LocPids, RemPids),
     checkpoint(before_check_fully_connected, JoinOpts),
     check_fully_connected(LocPids),
     check_fully_connected(RemPids).
 
--spec check_do_not_overlap([server_pid()], [server_pid()]) -> ok.
+-spec check_do_not_overlap(cets:servers(), cets:servers()) -> ok.
 check_do_not_overlap(LocPids, RemPids) ->
-    LocSet = ordsets:from_list(LocPids),
-    RemSet = ordsets:from_list(RemPids),
-    case ordsets:intersection(LocSet, RemSet) of
+    case ordsets:intersection(LocPids, RemPids) of
         [] ->
             ok;
         Overlap ->
             ?LOG_ERROR(#{
                 what => check_do_not_overlap_failed,
-                local_servers => LocSet,
-                remote_servers => RemSet,
+                local_servers => LocPids,
+                remote_servers => RemPids,
                 overlapped_servers => Overlap
             }),
             error(check_do_not_overlap_failed)
@@ -210,40 +210,40 @@ check_do_not_overlap(LocPids, RemPids) ->
 
 %% Checks that other_pids lists match for all nodes
 %% If they are not matching - the node removal process could be in progress
--spec check_fully_connected([server_pid()]) -> ok.
+-spec check_fully_connected(cets:servers()) -> ok.
 check_fully_connected(Pids) ->
     Lists = [get_pids(Pid) || Pid <- Pids],
-    case are_fully_connected_lists([Pids | Lists]) of
-        true ->
+    case lists:usort([Pids | Lists]) of
+        [_] ->
             check_same_join_ref(Pids);
-        false ->
+        UniqueLists ->
             ?LOG_ERROR(#{
                 what => check_fully_connected_failed,
                 expected_pids => Pids,
-                server_lists => Lists
+                server_lists => Lists,
+                unique_lists => UniqueLists
             }),
             error(check_fully_connected_failed)
     end.
 
-%% Check that all elements of the list match (if sorted)
-are_fully_connected_lists(Lists) ->
-    length(lists:usort([lists:sort(List) || List <- Lists])) =:= 1.
-
 %% Check if all nodes have the same join_ref
 %% If not - we don't want to continue joining
+-spec check_same_join_ref(cets:servers()) -> ok.
 check_same_join_ref(Pids) ->
     Refs = [pid_to_join_ref(Pid) || Pid <- Pids],
     case lists:usort(Refs) of
         [_] ->
             ok;
-        _ ->
+        UniqueRefs ->
             ?LOG_ERROR(#{
                 what => check_same_join_ref_failed,
-                refs => lists:zip(Pids, Refs)
+                refs => lists:zip(Pids, Refs),
+                unique_refs => UniqueRefs
             }),
             error(check_same_join_ref_failed)
     end.
 
+-spec pid_to_join_ref(server_pid()) -> join_ref().
 pid_to_join_ref(Pid) ->
     #{join_ref := JoinRef} = cets:info(Pid),
     JoinRef.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -322,7 +322,7 @@ insert_new_is_retried_when_leader_is_reelected(Config) ->
 
 %% We could retry automatically, but in this case return value from insert_new
 %% could be incorrect.
-%% If you wanna make insert_new more robust:
+%% If you want to make insert_new more robust:
 %% - handle cets_down exception
 %% - call insert_new one more time
 %% - read the data back using ets:lookup to ensure it is your record written

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -954,8 +954,7 @@ disco_handles_node_up_and_down(Config) ->
     Disco ! {nodeup, BadNode},
     Disco ! {nodedown, BadNode},
     %% Check that wait_for_ready still works
-    ok = cets_discovery:wait_for_ready(Disco, 5000),
-    ok.
+    ok = cets_discovery:wait_for_ready(Disco, 5000).
 
 test_locally(Config) ->
     #{tabs := [T1, T2]} = given_two_joined_tables(Config),
@@ -1229,7 +1228,7 @@ run_spawn_forwards_errors(_Config) ->
                 matched
         end.
 
-run_tracked_failed(Config) ->
+run_tracked_failed(_Config) ->
     matched =
         try
             F = fun() -> error(oops) end,
@@ -1386,9 +1385,11 @@ extra_args(ct5) -> ["-kernel", "prevent_overlapping_partitions", "false"];
 extra_args(_) -> "".
 
 start_node(Sname) ->
-    {ok, Peer, Node} = peer:start(#{
+    {ok, Peer, Node} = ?CT_PEER(#{
         name => Sname, connection => standard_io, args => extra_args(Sname)
     }),
+    %% Keep nodes running after init_per_suite is finished
+    unlink(Peer),
     %% Do RPC using alternative connection method
     ok = peer:call(Peer, code, add_paths, [code:get_path()]),
     {Node, Peer}.
@@ -1467,8 +1468,7 @@ wait_till_test_stage(Pid, Stage) ->
 %% Disconnect node until manually connected
 block_node(Node) ->
     rpc(Node, erlang, set_cookie, [invalid_cookie]),
-    rpc(Node, erlang, disconnect_node, [node()]),
-    ok.
+    rpc(Node, erlang, disconnect_node, [node()]).
 
 reconnect_node(Node) ->
     rpc(Node, erlang, set_cookie, [erlang:get_cookie()]),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -105,10 +105,13 @@ cases() ->
     ].
 
 init_per_suite(Config) ->
-    Node2 = start_node(ct2),
-    Node3 = start_node(ct3),
-    Node4 = start_node(ct4),
-    [{nodes, [Node2, Node3, Node4]} | Config].
+    Names = [ct2, ct3, ct4],
+    {Nodes, Peers} = lists:unzip([start_node(N) || N <- Names]),
+    [
+        {nodes, maps:from_list(lists:zip(Names, Nodes))},
+        {peers, maps:from_list(lists:zip(Names, Peers))}
+        | Config
+    ].
 
 end_per_suite(Config) ->
     Config.
@@ -641,7 +644,7 @@ send_dump_contains_already_added_servers(Config) ->
 
 test_multinode(Config) ->
     Node1 = node(),
-    [Node2, Node3, Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2, ct3 := Node3, ct4 := Node4} = proplists:get_value(peers, Config),
     Tab = make_name(Config),
     {ok, Pid1} = start(Node1, Tab),
     {ok, Pid2} = start(Node2, Tab),
@@ -681,7 +684,7 @@ test_multinode(Config) ->
 
 test_multinode_remote_insert(Config) ->
     Tab = make_name(Config),
-    [Node2, Node3 | _] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2, ct3 := Node3} = proplists:get_value(nodes, Config),
     {ok, Pid2} = start(Node2, Tab),
     {ok, Pid3} = start(Node3, Tab),
     ok = join(Node2, Tab, Pid2, Pid3),
@@ -693,7 +696,7 @@ test_multinode_remote_insert(Config) ->
 
 node_list_is_correct(Config) ->
     Node1 = node(),
-    [Node2, Node3, Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2, ct3 := Node3, ct4 := Node4} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, Pid1} = start(Node1, Tab),
     {ok, Pid2} = start(Node2, Tab),
@@ -710,7 +713,7 @@ node_list_is_correct(Config) ->
 
 test_multinode_auto_discovery(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _Pid1} = start(Node1, Tab),
     {ok, _Pid2} = start(Node2, Tab),
@@ -729,7 +732,7 @@ test_multinode_auto_discovery(Config) ->
 
 test_multinode_auto_discovery_with_wait_for_ready(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _Pid1} = start(Node1, Tab),
     {ok, _Pid2} = start(Node2, Tab),
@@ -748,7 +751,7 @@ test_multinode_auto_discovery_with_wait_for_ready(Config) ->
 
 test_disco_add_table(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _Pid1} = start(Node1, Tab),
     {ok, _Pid2} = start(Node2, Tab),
@@ -766,7 +769,7 @@ test_disco_add_table(Config) ->
 
 test_disco_handles_bad_node(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _Pid1} = start(Node1, Tab),
     {ok, _Pid2} = start(Node2, Tab),
@@ -786,7 +789,7 @@ test_disco_handles_bad_node(Config) ->
 
 cets_discovery_fun_backend_works(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _Pid1} = start(Node1, Tab),
     {ok, _Pid2} = start(Node2, Tab),
@@ -810,7 +813,7 @@ test_disco_add_table_twice(Config) ->
 
 test_disco_add_two_tables(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab1 = make_name(Config, 1),
     Tab2 = make_name(Config, 2),
     {ok, _} = start(Node1, Tab1),
@@ -853,7 +856,7 @@ test_disco_add_two_tables(Config) ->
 
 disco_retried_if_get_nodes_fail(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _} = start(Node1, Tab),
     {ok, _} = start(Node2, Tab),
@@ -870,7 +873,7 @@ disco_retried_if_get_nodes_fail(Config) ->
 
 disco_uses_regular_retry_interval_in_the_regular_phase(Config) ->
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _} = start(Node1, Tab),
     {ok, _} = start(Node2, Tab),
@@ -886,7 +889,7 @@ disco_uses_regular_retry_interval_in_the_regular_phase(Config) ->
 disco_handles_node_up_and_down(Config) ->
     BadNode = 'badnode@localhost',
     Node1 = node(),
-    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
     Tab = make_name(Config),
     {ok, _} = start(Node1, Tab),
     {ok, _} = start(Node2, Tab),
@@ -1249,7 +1252,15 @@ other_nodes(Node, Tab) ->
 join(Node1, Tab, Pid1, Pid2) ->
     rpc(Node1, cets_join, join, [lock1, #{table => Tab}, Pid1, Pid2]).
 
-rpc(Node, M, F, Args) ->
+%% Apply function using rpc or peer module
+rpc(Peer, M, F, Args) when is_pid(Peer) ->
+    case peer:call(Peer, M, F, Args) of
+        {badrpc, Error} ->
+            ct:fail({badrpc, Error});
+        Other ->
+            Other
+    end;
+rpc(Node, M, F, Args) when is_atom(Node) ->
     case rpc:call(Node, M, F, Args) of
         {badrpc, Error} ->
             ct:fail({badrpc, Error});
@@ -1258,9 +1269,10 @@ rpc(Node, M, F, Args) ->
     end.
 
 start_node(Sname) ->
-    {ok, _Peer, Node} = peer:start(#{name => Sname}),
-    ok = rpc:call(Node, code, add_paths, [code:get_path()]),
-    Node.
+    {ok, Peer, Node} = peer:start(#{name => Sname, connection => standard_io}),
+    %% Do RPC using alternative connection method
+    ok = peer:call(Peer, code, add_paths, [code:get_path()]),
+    {Node, Peer}.
 
 receive_message(M) ->
     receive

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -1256,6 +1256,8 @@ send_leader_op_throws_noproc(_Config) ->
                 matched
         end.
 
+%% Netsplit cases (run in sequence)
+
 insert_returns_when_netsplit(Config) ->
     #{ct5 := Node2} = proplists:get_value(peers, Config),
     Node1 = node(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -62,6 +62,7 @@ cases() ->
         test_multinode_auto_discovery,
         test_multinode_auto_discovery_with_wait_for_ready,
         test_disco_add_table,
+        test_disco_add_table_twice,
         test_locally,
         handle_down_is_called,
         events_are_applied_in_the_correct_order_after_unpause,
@@ -756,6 +757,16 @@ test_disco_add_table(Config) ->
     [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
         cets_discovery:info(Disco),
     ok.
+
+test_disco_add_table_twice(Config) ->
+    Dir = proplists:get_value(priv_dir, Config),
+    FileName = filename:join(Dir, "disco.txt"),
+    {ok, Disco} = cets_discovery:start(#{tables => [], disco_file => FileName}),
+    Tab = make_name(Config),
+    {ok, _Pid} = start_local(Tab),
+    cets_discovery:add_table(Disco, Tab),
+    cets_discovery:add_table(Disco, Tab),
+    #{tables := [Tab]} = cets_discovery:system_info(Disco).
 
 test_locally(Config) ->
     #{tabs := [T1, T2]} = given_two_joined_tables(Config),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -711,9 +711,8 @@ test_multinode_auto_discovery(Config) ->
     FileName = filename:join(Dir, "disco.txt"),
     ok = file:write_file(FileName, io_lib:format("~s~n~s~n", [Node1, Node2])),
     {ok, Disco} = cets_discovery:start(#{tables => [Tab], disco_file => FileName}),
-    %% Waits for the first check
-    sys:get_state(Disco),
-    [Node2] = other_nodes(Node1, Tab),
+    %% Disco is async, so we have to wait for the final state
+    cets_test_wait:wait_until(fun() -> other_nodes(Node1, Tab) end, [Node2]),
     [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
         cets_discovery:info(Disco),
     ok.
@@ -730,9 +729,8 @@ test_disco_add_table(Config) ->
     ok = file:write_file(FileName, io_lib:format("~s~n~s~n", [Node1, Node2])),
     {ok, Disco} = cets_discovery:start(#{tables => [], disco_file => FileName}),
     cets_discovery:add_table(Disco, Tab),
-    %% Waits for the first check
-    sys:get_state(Disco),
-    [Node2] = other_nodes(Node1, Tab),
+    %% Disco is async, so we have to wait for the final state
+    cets_test_wait:wait_until(fun() -> other_nodes(Node1, Tab) end, [Node2]),
     [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
         cets_discovery:info(Disco),
     ok.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -107,6 +107,7 @@ cases() ->
         code_change_returns_ok,
         code_change_returns_ok_for_ack,
         run_spawn_forwards_errors,
+        run_tracked_failed,
         long_call_to_unknown_name_throws_pid_not_found,
         send_leader_op_throws_noproc
     ].
@@ -1223,6 +1224,16 @@ run_spawn_forwards_errors(_Config) ->
     matched =
         try
             cets_long:run_spawn(#{}, fun() -> error(oops) end)
+        catch
+            error:oops ->
+                matched
+        end.
+
+run_tracked_failed(Config) ->
+    matched =
+        try
+            F = fun() -> error(oops) end,
+            cets_long:run_tracked(#{}, F)
         catch
             error:oops ->
                 matched

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -60,6 +60,7 @@ cases() ->
         test_multinode_remote_insert,
         node_list_is_correct,
         test_multinode_auto_discovery,
+        test_multinode_auto_discovery_with_wait_for_ready,
         test_disco_add_table,
         test_locally,
         handle_down_is_called,
@@ -715,6 +716,27 @@ test_multinode_auto_discovery(Config) ->
     cets_test_wait:wait_until(fun() -> other_nodes(Node1, Tab) end, [Node2]),
     [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
         cets_discovery:info(Disco),
+    #{verify_ready := []} =
+        cets_discovery:system_info(Disco),
+    ok.
+
+test_multinode_auto_discovery_with_wait_for_ready(Config) ->
+    Node1 = node(),
+    [Node2, _Node3, _Node4] = proplists:get_value(nodes, Config),
+    Tab = make_name(Config),
+    {ok, _Pid1} = start(Node1, Tab),
+    {ok, _Pid2} = start(Node2, Tab),
+    Dir = proplists:get_value(priv_dir, Config),
+    ct:pal("Dir ~p", [Dir]),
+    FileName = filename:join(Dir, "disco.txt"),
+    ok = file:write_file(FileName, io_lib:format("~s~n~s~n", [Node1, Node2])),
+    {ok, Disco} = cets_discovery:start(#{tables => [Tab], disco_file => FileName}),
+    ok = cets_discovery:wait_for_ready(Disco, 5000),
+    [Node2] = other_nodes(Node1, Tab),
+    [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
+        cets_discovery:info(Disco),
+    #{verify_ready := []} =
+        cets_discovery:system_info(Disco),
     ok.
 
 test_disco_add_table(Config) ->

--- a/test/cets_discovery_fun.erl
+++ b/test/cets_discovery_fun.erl
@@ -1,0 +1,9 @@
+-module(cets_discovery_fun).
+-behaviour(cets_discovery).
+-export([init/1, get_nodes/1]).
+
+init(Opts) ->
+    Opts.
+
+get_nodes(State = #{get_nodes_fn := F}) ->
+    F(State).


### PR DESCRIPTION
Adresses MIM-2018.

Make cets_discovery module more async and better tested.
This should avoid long locking time at startup in some cases (for example, there are a lot of dead nodes returned by the discovery backend).


Changes:
- Make discovery gen_server non-blocking.
- Adding wait_for_ready functionality - could be useful to avoid not-fully ready servers to be exposed to the users (i.e. to avoid accepting incoming connection on a new node, before it copied the session table, for example)
- Smarter timeouts for retries. We use a different timeout after an error. We also don't call get_nodes too often once started.
- Specs.
- More tests with better coverage.
- Fixes small race conditions in insert_new tests (rare, but they were found by rerunning tests).
- Use peer module to do RPCs.
- Some netsplit tests.


You can find MIM branch that uses this code here: https://github.com/esl/MongooseIM/pull/4111 (for testing)

Command to test helm (ensure you use k8s from Docker Desktop and having helm installed):
```bash
# Setup DB using MIM test scripts:
DB="pgsql" ./tools/setup-db.sh
# Ensure MIM stopped...
killall beam.smp
# Get helm scripts
git clone https://github.com/esl/MongooseHelm.git
cd MongooseHelm
# Ensure old hem cluster is dead
helm uninstall mim-test
# Test with these changes
helm install mim-test MongooseIM --set replicaCount=3 --set image.tag=PR-4111 --set persistentDatabase=rdbms --set rdbms.username=ejabberd --set rdbms.password=mongooseim_secret --set rdbms.database=ejabberd --set volatileDatabase=cets
# Check that all is fine in logs:
kubectl get pod
kubectl logs mongooseim-0
kubectl exec -it mongooseim-0 -- mongooseimctl cets systemInfo
```