### PR TITLE
Use pmap in some places

### DIFF
--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -114,7 +114,7 @@ get_tables(Server) ->
 -spec info(server()) -> [cets:info()].
 info(Server) ->
     {ok, Tables} = get_tables(Server),
-    [cets:info(Tab) || Tab <- Tables].
+    cets_pmap:map(fun cets:info/1, Tables).
 
 -spec system_info(server()) -> system_info().
 system_info(Server) ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -212,7 +212,7 @@ check_do_not_overlap(LocPids, RemPids) ->
 %% If they are not matching - the node removal process could be in progress
 -spec check_fully_connected(cets:servers()) -> ok.
 check_fully_connected(Pids) ->
-    Lists = [get_pids(Pid) || Pid <- Pids],
+    Lists = cets_pmap:map(fun get_pids/1, Pids),
     case lists:usort([Pids | Lists]) of
         [_] ->
             check_same_join_ref(Pids);
@@ -230,7 +230,7 @@ check_fully_connected(Pids) ->
 %% If not - we don't want to continue joining
 -spec check_same_join_ref(cets:servers()) -> ok.
 check_same_join_ref(Pids) ->
-    Refs = [pid_to_join_ref(Pid) || Pid <- Pids],
+    Refs = cets_pmap:map(fun pid_to_join_ref/1, Pids),
     case lists:usort(Refs) of
         [_] ->
             ok;

--- a/src/cets_pmap.erl
+++ b/src/cets_pmap.erl
@@ -1,0 +1,43 @@
+-module(cets_pmap).
+-export([map/2]).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% Applies F for all elements in parallel
+%% Waits forever for the results
+%% Forwards crashes (i.e. raises an error in the context of the caller process)
+-spec map(fun((term()) -> term()), list()) -> list().
+map(F, Elems) when is_function(F, 1) ->
+    Pids = [apply_async(F, Elem) || Elem <- Elems],
+    Results = [wait_for_result(Pid) || Pid <- Pids],
+    [unpack(Result) || Result <- Results].
+
+apply_async(F, Elem) ->
+    Me = self(),
+    spawn_link(fun() -> Me ! {result, self(), safe_apply(F, Elem)} end).
+
+wait_for_result(Pid) ->
+    receive
+        {result, Pid, Res} ->
+            Res
+    end.
+
+unpack({ok, X}) ->
+    X;
+unpack({error, {Class, Reason, Stacktrace}}) ->
+    erlang:raise(Class, Reason, Stacktrace).
+
+safe_apply(F, Argument) when is_function(F, 1) ->
+    try
+        {ok, F(Argument)}
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{
+                what => pmap_apply,
+                argument => Argument,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            {error, {Class, Reason, Stacktrace}}
+    end.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -109,7 +109,9 @@ cases() ->
         run_spawn_forwards_errors,
         run_tracked_failed,
         long_call_to_unknown_name_throws_pid_not_found,
-        send_leader_op_throws_noproc
+        send_leader_op_throws_noproc,
+        pmap_works,
+        pmap_crashes
     ].
 
 seq_cases() ->
@@ -157,7 +159,7 @@ end_per_testcase(_, _Config) ->
 
 %% Modules that use a multiline LOG_ macro
 log_modules() ->
-    [cets, cets_call, cets_join].
+    [cets, cets_call, cets_join, cets_pmap].
 
 inserted_records_could_be_read_back(Config) ->
     Tab = make_name(Config),
@@ -1253,6 +1255,18 @@ send_leader_op_throws_noproc(_Config) ->
             cets_call:send_leader_op(unknown_name_please, {op, {insert, {1}}})
         catch
             exit:{noproc, {gen_server, call, [unknown_name_please, get_leader]}} ->
+                matched
+        end.
+
+pmap_works(_Config) ->
+    [2, 4, 6] = cets_pmap:map(fun(X) -> X * 2 end, [1, 2, 3]).
+
+pmap_crashes(_Config) ->
+    matched =
+        try
+            cets_pmap:map(fun(X) -> X * 2 end, [1, x, 3])
+        catch
+            error:badarith ->
                 matched
         end.
 


### PR DESCRIPTION
Use pmap in some places

- Pretty simple implementation for places which are not called often but could be blocking for some time
- We could use gen_server:request API to avoid an extra spawn, but lets keep code simple. 

Alternatives:
- we cannot use rpc:pmap, it evals function on random nodes.  We have to implement pmap on our own (again).
- We could use wait_response/3 instead, once MIM drops OTP24 - https://www.erlang.org/doc/man/gen_server#wait_response-3   -- it allows to wait for sevaral requests at once (but we would have to actually rewrite our API functions to support requests :(). And we would avoid new spawns in this case.
API is ugly though: https://www.erlang.org/doc/man/gen_server#reqids_add-3