### PR TITLE
Check that nodes are fully connected before allowing to join

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,9 @@
         {plugins, [erlfmt]}
     ]},
     {test, [
+        {deps, [
+            {logger_debug_h, "0.1.0"}
+        ]},
         {plugins, [
             {rebar3_codecov, "0.6.0"}
         ]}

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -2,6 +2,10 @@
 -module(cets_long).
 -export([run_spawn/2, run_tracked/2]).
 
+-ifdef(TEST).
+-export([pinfo/2]).
+-endif.
+
 -include_lib("kernel/include/logger.hrl").
 
 %% Extra logging information

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -14,7 +14,7 @@ all() ->
 
 groups() ->
     [
-        {cets, [parallel, {repeat_until_any_fail, 3}], cases()},
+        {cets, [parallel, {repeat_until_any_fail, 3}], cases() ++ only_for_logger_cases()},
         {cets_no_log, [parallel], cases()},
         %% These tests actually simulate a netsplit on the distribution level.
         %% Though, global's prevent_overlapping_partitions option starts kicking
@@ -114,6 +114,11 @@ cases() ->
         send_leader_op_throws_noproc
     ].
 
+only_for_logger_cases() ->
+    [
+        run_tracked_logged_check_logger
+    ].
+
 seq_cases() ->
     [
         insert_returns_when_netsplit,
@@ -161,7 +166,7 @@ end_per_testcase(_, _Config) ->
 
 %% Modules that use a multiline LOG_ macro
 log_modules() ->
-    [cets, cets_call, cets_join].
+    [cets, cets_call, cets_long, cets_join].
 
 inserted_records_could_be_read_back(Config) ->
     Tab = make_name(Config),
@@ -1252,6 +1257,10 @@ run_tracked_failed(_Config) ->
         end.
 
 run_tracked_logged(_Config) ->
+    F = fun() -> timer:sleep(100) end,
+    cets_long:run_tracked(#{report_interval => 10}, F).
+
+run_tracked_logged_check_logger(_Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     F = fun() -> timer:sleep(5000) end,
     %% Run it in a separate process, so we can check logs in the test process

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -1333,7 +1333,8 @@ joining_not_fully_connected_node_is_not_allowed(Config) ->
         %% Pid2 and Pid3 could contact each other.
         %% Pid3 could contact Pid1 (they are joined).
         %% But Pid2 cannot contact Pid1.
-        {error, _} = rpc(Node2, cets_join, join, [lock_name(Config), #{}, Pid2, Pid3]),
+        {error, {{nodedown, Node1}, {gen_server, call, [_, other_servers, infinity]}}} =
+            rpc(Node2, cets_join, join, [lock_name(Config), #{}, Pid2, Pid3]),
         %% Still connected
         cets:insert(Pid1, {r1}),
         {ok, [{r1}]} = cets:remote_dump(Pid3),
@@ -1359,7 +1360,9 @@ joining_not_fully_connected_node_is_not_allowed2(Config) ->
         %% Pid2 and Pid3 could contact each other.
         %% Pid3 could contact Pid1 (they are joined).
         %% But Pid2 cannot contact Pid1.
-        {error, _} = rpc(Node3, cets_join, join, [lock_name(Config), #{}, Pid2, Pid3]),
+        {error, check_could_reach_each_other_failed} = rpc(Node3, cets_join, join, [
+            lock_name(Config), #{}, Pid2, Pid3
+        ]),
         %% Still connected
         cets:insert(Pid1, {r1}),
         {ok, [{r1}]} = cets:remote_dump(Pid3),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -98,6 +98,7 @@ cases() ->
         insert_into_keypos_table,
         table_name_works,
         info_contains_opts,
+        check_could_reach_each_other_fails,
         unknown_down_message_is_ignored,
         unknown_message_is_ignored,
         unknown_cast_message_is_ignored,
@@ -1172,6 +1173,15 @@ info_contains_opts(Config) ->
     {ok, Pid} = start_local(T, #{type => bag}),
     #{opts := #{type := bag}} = cets:info(Pid).
 
+check_could_reach_each_other_fails(_Config) ->
+    matched =
+        try
+            cets_join:check_could_reach_each_other([self()], [bad_node_pid()])
+        catch
+            error:check_could_reach_each_other_failed ->
+                matched
+        end.
+
 %% Cases to improve code coverage
 
 unknown_down_message_is_ignored(Config) ->
@@ -1539,3 +1549,11 @@ not_leader(Leader, Other, Leader) ->
     Other;
 not_leader(Other, Leader, Leader) ->
     Other.
+
+bad_node_pid() ->
+    binary_to_term(bad_node_pid_binary()).
+
+bad_node_pid_binary() ->
+    %% Pid <0.90.0> on badnode@localhost
+    <<131, 88, 100, 0, 17, 98, 97, 100, 110, 111, 100, 101, 64, 108, 111, 99, 97, 108, 104, 111,
+        115, 116, 0, 0, 0, 90, 0, 0, 0, 0, 100, 206, 70, 92>>.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -111,7 +111,9 @@ cases() ->
         run_tracked_failed,
         run_tracked_logged,
         long_call_to_unknown_name_throws_pid_not_found,
-        send_leader_op_throws_noproc
+        send_leader_op_throws_noproc,
+        pinfo_returns_value,
+        pinfo_returns_undefined
     ].
 
 only_for_logger_cases() ->
@@ -1295,6 +1297,12 @@ send_leader_op_throws_noproc(_Config) ->
                 matched
         end.
 
+pinfo_returns_value(_Config) ->
+    true = is_list(cets_long:pinfo(self(), messages)).
+
+pinfo_returns_undefined(_Config) ->
+    undefined = cets_long:pinfo(stopped_pid(), messages).
+
 %% Netsplit cases (run in sequence)
 
 insert_returns_when_netsplit(Config) ->
@@ -1553,7 +1561,8 @@ stopped_pid() ->
     {Pid, Mon} = spawn_monitor(fun() -> ok end),
     receive
         {'DOWN', Mon, process, Pid, _Reason} -> ok
-    end.
+    end,
+    Pid.
 
 get_pd(Pid, Key) ->
     {dictionary, Dict} = erlang:process_info(Pid, dictionary),


### PR DESCRIPTION
Checks that nodes are fully connected (could send messages to each other) before allowing to join. MIM-2023

It should allow to not join with a node, which is netsplitted or have a wrong network configuration (and prevent_overlapping_partitions is false).



It **does not** address case when a node permanently looses connectivity to some part of the cluster. We would have to do it separately, because there are many ways to choose which nodes should be disconnected when they loose partial connectivity to the cluster (i.e. we would have to decide on voting + healthcheck)

Also, the motivation is to be able to not allow bad (not fully connected in the sense of erlang distribution) nodes to rejoin, after we would design code which would kick nodes out of the cluster.