### PR TITLE
Disable checkpoints for the prod builds

### DIFF
--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -257,6 +257,7 @@ checkpoint(CheckPointName, #{checkpoint_handler := F}) ->
 checkpoint(_CheckPointName, _Opts) ->
     ok.
 -else.
+-compile({inline, [checkpoint/2]}).
 checkpoint(_CheckPointName, _Opts) ->
     ok.
 -endif.

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -251,7 +251,12 @@ pid_to_join_ref(Pid) ->
 %% Checkpoints are used for testing
 %% Checkpoints do nothing in production
 -spec checkpoint(checkpoint(), join_opts()) -> ok.
+-ifdef(TEST).
 checkpoint(CheckPointName, #{checkpoint_handler := F}) ->
     F(CheckPointName);
 checkpoint(_CheckPointName, _Opts) ->
     ok.
+-else.
+checkpoint(_CheckPointName, _Opts) ->
+    ok.
+-endif.


### PR DESCRIPTION
As they are just for testing, we could disable them.