### PR TITLE
Add cets_status module

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -304,7 +304,7 @@ get_leader(Server) ->
     gen_server:call(Server, get_leader).
 
 %% Get a list of other nodes in the cluster that are connected together.
--spec other_nodes(server_ref()) -> [node()].
+-spec other_nodes(server_ref()) -> ordsets:ordset(node()).
 other_nodes(Server) ->
     lists:usort(pids_to_nodes(other_pids(Server))).
 

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -27,7 +27,7 @@
 -module(cets_discovery).
 -behaviour(gen_server).
 
--export([start/1, start_link/1, add_table/2, info/1, system_info/1, wait_for_ready/2]).
+-export([start/1, start_link/1, add_table/2, get_tables/1, info/1, system_info/1, wait_for_ready/2]).
 -export([
     init/1,
     handle_call/3,
@@ -38,7 +38,14 @@
 ]).
 
 -ignore_xref([
-    start/1, start_link/1, add_table/2, info/1, system_info/1, wait_for_ready/2, behaviour_info/1
+    start/1,
+    start_link/1,
+    add_table/2,
+    get_tables/1,
+    info/1,
+    system_info/1,
+    wait_for_ready/2,
+    behaviour_info/1
 ]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -47,7 +54,7 @@
 -type get_nodes_result() :: {ok, [node()]} | {error, term()}.
 -type retry_type() :: initial | after_error | regular.
 
--export_type([get_nodes_result/0]).
+-export_type([get_nodes_result/0, system_info/0]).
 
 -type from() :: {pid(), reference()}.
 -type join_result() :: #{

--- a/src/cets_status.erl
+++ b/src/cets_status.erl
@@ -8,83 +8,142 @@
 -type disco_name() :: atom().
 
 -type info() :: #{
-    unavailable_nodes => [node()],
-    available_nodes => [node()],
-    joined_nodes => [node()],
-    partially_joined_nodes => [node()],
-    partially_joined_tables => [table_name()],
-    discovered_nodes => [node()],
-    discovery_works => boolean()
+    %% Nodes that are connected to us and have the CETS disco process started.
+    available_nodes := [node()],
+    %% Nodes that do not respond to our pings.
+    unavailable_nodes := [node()],
+    %% Nodes with stopped disco
+    remote_nodes_without_disco := [node()],
+    %% Nodes that has our local tables running (but could also have some unknown tables).
+    %% All joined nodes replicate data between each other.
+    joined_nodes := [node()],
+    %% Nodes that have more tables registered than the local node.
+    remote_nodes_with_unknown_tables := [node()],
+    remote_unknown_tables := [table_name()],
+    %% Nodes that are available, but do not host one of our local tables.
+    remote_nodes_with_missing_tables => [node()],
+    remote_missing_tables := [table_name()],
+    %% Nodes that replicate at least one of our local tables to a different list of nodes
+    %% (could temporary happen during a netsplit)
+    conflict_nodes := [node()],
+    conflict_tables := [table_name()],
+    %% Nodes that are extracted from the discovery backend.
+    discovered_nodes := [node()],
+    %% True, if discovery backend returned the list of nodes the last time we've tried
+    %% to call it.
+    discovery_works := boolean()
 }.
 
 -spec status(disco_name()) -> info().
 status(Disco) when is_atom(Disco) ->
     %% The node lists could not match for different nodes
     %% because they are updated periodically
-    #{unavailable_nodes := UnNodes, nodes := Nodes, tables := Tables} =
+    #{unavailable_nodes := UnNodes, nodes := DiscoNodes, tables := Tables} =
         Info = cets_discovery:system_info(Disco),
-    NodesSorted = lists:sort(Nodes),
-    AvailNodes = available_nodes(Disco),
-    {JoinedNodes, PartTables} = filter_joined_nodes(AvailNodes, Tables, Disco),
-    PartNodes = AvailNodes -- JoinedNodes,
+    DiscoNodesSorted = lists:sort(DiscoNodes),
+    OnlineNodes = [node() | nodes()],
+    AvailNodes = available_nodes(Disco, OnlineNodes),
+    NoDiscoNodes = remote_nodes_without_disco(DiscoNodesSorted, AvailNodes, OnlineNodes),
+    {Expected, OtherTabNodes} = gather_tables_and_replication_nodes(AvailNodes, Tables, Disco),
+    JoinedNodes = joined_nodes(Expected, OtherTabNodes),
+    {ConflictTables, ConflictNodes} = conflict_tables(Expected, OtherTabNodes),
+    AllTables = all_tables(Expected, OtherTabNodes),
+    {UnknownTables, NodesWithUnknownTables} = unknown_tables(OtherTabNodes, Tables, AllTables),
     #{
         unavailable_nodes => UnNodes,
         available_nodes => AvailNodes,
+        remote_nodes_without_disco => NoDiscoNodes,
         joined_nodes => JoinedNodes,
-        partially_joined_nodes => PartNodes,
-        partially_joined_tables => PartTables,
-        discovered_nodes => NodesSorted,
+        remote_nodes_with_unknown_tables => NodesWithUnknownTables,
+        remote_unknown_tables => UnknownTables,
+        conflict_nodes => ConflictNodes,
+        conflict_tables => ConflictTables,
+        discovered_nodes => DiscoNodesSorted,
         discovery_works => discovery_works(Info)
     }.
 
 %% Nodes, that host the discovery process
--spec available_nodes(disco_name()) -> [node()].
-available_nodes(Disco) ->
-    OnlineNodes = [node() | nodes()],
+-spec available_nodes(disco_name(), [node()]) -> [node()].
+available_nodes(Disco, OnlineNodes) ->
     [Node || Node <- OnlineNodes, is_disco_running_on(Node, Disco)].
+
+remote_nodes_without_disco(DiscoNodes, AvailNodes, OnlineNodes) ->
+    [
+        Node
+     || Node <- DiscoNodes, lists:member(Node, OnlineNodes), not lists:member(Node, AvailNodes)
+    ].
 
 -spec is_disco_running_on(node(), disco_name()) -> boolean().
 is_disco_running_on(Node, Disco) ->
     is_pid(rpc:call(Node, erlang, whereis, [Disco])).
 
-%% Returns only nodes that replicate all our local CETS tables to the same list of remote nodes
-%% (and do not have some unknown tables)
--spec filter_joined_nodes(AvailNodes :: [node()], Tables :: [table_name()], Disco :: disco_name()) ->
-    {JoinedNodes :: [node()], PartTables :: [table_name()]}.
-filter_joined_nodes(AvailNodes, Tables, Disco) ->
+gather_tables_and_replication_nodes(AvailNodes, Tables, Disco) ->
     OtherNodes = lists:delete(node(), AvailNodes),
     Expected = node_list_for_tables(node(), Tables),
-    OtherTables = [{Node, node_list_for_tables_from_disco(Node, Disco)} || Node <- OtherNodes],
-    OtherJoined = [Node || {Node, NodeTabs} <- OtherTables, NodeTabs =:= Expected],
-    JoinedNodes = lists:sort([node() | OtherJoined]),
-    PartTables = filter_partially_joined_tables(Expected, OtherTables),
-    {JoinedNodes, PartTables}.
+    OtherTabNodes = [{Node, node_list_for_tables_from_disco(Node, Disco)} || Node <- OtherNodes],
+    {Expected, maps:from_list(OtherTabNodes)}.
 
-%% Partially joined means that:
-%% - one of the nodes has a table not known to other nodes
-%% - or some tables are not joined by all nodes
--spec filter_partially_joined_tables([tab_nodes()], [{node(), [tab_nodes()]}]) -> [table_name()].
-filter_partially_joined_tables(Expected, OtherTables) ->
-    TableNodesVariants = [Expected | [NodeTabs || {_Node, NodeTabs} <- OtherTables]],
-    TableVariants = lists:map(fun tab_nodes_to_tables/1, TableNodesVariants),
-    SharedTables = ordsets:intersection(TableVariants),
-    AllTables = ordsets:union(TableVariants),
-    ordsets:subtract(AllTables, SharedTables).
+%% Nodes that has our local tables running (but could also have some unknown tables).
+%% All joined nodes replicate data between each other.
+joined_nodes(Expected, OtherTabNodes) ->
+    ExpectedTables = maps:keys(Expected),
+    OtherJoined = [
+        Node
+     || {Node, NodeTabs} <- maps:to_list(OtherTabNodes),
+        maps:with(ExpectedTables, NodeTabs) =:= Expected
+    ],
+    lists:sort([node() | OtherJoined]).
 
--spec tab_nodes_to_tables([tab_nodes()]) -> [table_name()].
-tab_nodes_to_tables(TabNodes) ->
-    [Table || {Table, [_ | _] = _Nodes} <- TabNodes].
+unknown_tables(OtherTabNodes, Tables, AllTables) ->
+    UnknownTables = ordsets:subtract(AllTables, Tables),
+    NodesWithUnknownTables = [
+        Node
+     || {Node, TabNodes} <- maps:to_list(OtherTabNodes),
+        tabnodes_has_any_of(TabNodes, UnknownTables)
+    ],
+    {UnknownTables, NodesWithUnknownTables}.
+
+tabnodes_has_any_of(TabNodes, UnknownTables) ->
+    lists:any(fun(Tab) -> maps:is_key(Tab, TabNodes) end, UnknownTables).
+
+%% Nodes that replicate at least one of our local tables to a different list of nodes
+%% (could temporary happen during a netsplit)
+-spec conflict_tables([tab_nodes()], [{node(), [tab_nodes()]}]) -> {[table_name()], [table_name()]}.
+conflict_tables(Expected, OtherTabNodes) ->
+    F = fun(Node, NodeTabs, Acc) ->
+        FF = fun(Table, OtherNodes, Acc2) ->
+            case maps:get(Table, Expected, undefined) of
+                Nodes when Nodes =:= OtherNodes ->
+                    Acc2;
+                undefined ->
+                    Acc2;
+                _ ->
+                    [{Table, Node} | Acc2]
+            end
+        end,
+        maps:fold(FF, Acc, NodeTabs)
+    end,
+    TabNodes = maps:fold(F, [], OtherTabNodes),
+    {ConflictTables, ConflictNodes} = lists:unzip(TabNodes),
+    {lists:usort(ConflictTables), lists:usort(ConflictNodes)}.
+
+-spec all_tables([tab_nodes()], [{node(), [tab_nodes()]}]) -> [table_name()].
+all_tables(Expected, OtherTabNodes) ->
+    TableNodesVariants = [Expected | maps:values(OtherTabNodes)],
+    TableVariants = lists:map(fun maps:keys/1, TableNodesVariants),
+    %   SharedTables = ordsets:intersection(TableVariants),
+    ordsets:union(TableVariants).
 
 %% Returns nodes for each table hosted on node()
--spec node_list_for_tables_from_disco(node(), disco_name()) -> [tab_nodes()].
+-spec node_list_for_tables_from_disco(node(), disco_name()) -> map().
 node_list_for_tables_from_disco(Node, Disco) ->
     Tables = get_tables_list_on_node(Node, Disco),
     node_list_for_tables(Node, Tables).
 
 %% Returns nodes for each table in the Tables list
--spec node_list_for_tables(node(), [table_name()]) -> [tab_nodes()].
+-spec node_list_for_tables(node(), [table_name()]) -> map().
 node_list_for_tables(Node, Tables) ->
-    [{Table, node_list_for_table(Node, Table)} || Table <- Tables].
+    maps:from_list([{Table, node_list_for_table(Node, Table)} || Table <- Tables]).
 
 -spec get_tables_list_on_node(Node :: node(), Disco :: disco_name()) -> [table_name()].
 get_tables_list_on_node(Node, Disco) ->

--- a/src/cets_status.erl
+++ b/src/cets_status.erl
@@ -1,0 +1,115 @@
+-module(cets_status).
+-export([status/1]).
+-ignore_xref([status/1]).
+-include_lib("kernel/include/logger.hrl").
+
+-type tab_nodes() :: {Table :: atom(), Nodes :: ordsets:ordset(node())}.
+-type table_name() :: cets:table_name().
+-type disco_name() :: atom().
+
+-type info() :: #{
+    unavailable_nodes => [node()],
+    available_nodes => [node()],
+    joined_nodes => [node()],
+    partially_joined_nodes => [node()],
+    partially_joined_tables => [table_name()],
+    discovered_nodes => [node()],
+    discovery_works => boolean()
+}.
+
+-spec status(disco_name()) -> info().
+status(Disco) when is_atom(Disco) ->
+    %% The node lists could not match for different nodes
+    %% because they are updated periodically
+    #{unavailable_nodes := UnNodes, nodes := Nodes, tables := Tables} =
+        Info = cets_discovery:system_info(Disco),
+    NodesSorted = lists:sort(Nodes),
+    AvailNodes = available_nodes(Disco),
+    {JoinedNodes, PartTables} = filter_joined_nodes(AvailNodes, Tables, Disco),
+    PartNodes = AvailNodes -- JoinedNodes,
+    #{
+        unavailable_nodes => UnNodes,
+        available_nodes => AvailNodes,
+        joined_nodes => JoinedNodes,
+        partially_joined_nodes => PartNodes,
+        partially_joined_tables => PartTables,
+        discovered_nodes => NodesSorted,
+        discovery_works => discovery_works(Info)
+    }.
+
+%% Nodes, that host the discovery process
+-spec available_nodes(disco_name()) -> [node()].
+available_nodes(Disco) ->
+    OnlineNodes = [node() | nodes()],
+    [Node || Node <- OnlineNodes, is_disco_running_on(Node, Disco)].
+
+-spec is_disco_running_on(node(), disco_name()) -> boolean().
+is_disco_running_on(Node, Disco) ->
+    is_pid(rpc:call(Node, erlang, whereis, [Disco])).
+
+%% Returns only nodes that replicate all our local CETS tables to the same list of remote nodes
+%% (and do not have some unknown tables)
+-spec filter_joined_nodes(AvailNodes :: [node()], Tables :: [table_name()], Disco :: disco_name()) ->
+    {JoinedNodes :: [node()], PartTables :: [table_name()]}.
+filter_joined_nodes(AvailNodes, Tables, Disco) ->
+    OtherNodes = lists:delete(node(), AvailNodes),
+    Expected = node_list_for_tables(node(), Tables),
+    OtherTables = [{Node, node_list_for_tables_from_disco(Node, Disco)} || Node <- OtherNodes],
+    OtherJoined = [Node || {Node, NodeTabs} <- OtherTables, NodeTabs =:= Expected],
+    JoinedNodes = lists:sort([node() | OtherJoined]),
+    PartTables = filter_partially_joined_tables(Expected, OtherTables),
+    {JoinedNodes, PartTables}.
+
+%% Partially joined means that:
+%% - one of the nodes has a table not known to other nodes
+%% - or some tables are not joined by all nodes
+-spec filter_partially_joined_tables([tab_nodes()], [{node(), [tab_nodes()]}]) -> [table_name()].
+filter_partially_joined_tables(Expected, OtherTables) ->
+    TableNodesVariants = [Expected | [NodeTabs || {_Node, NodeTabs} <- OtherTables]],
+    TableVariants = lists:map(fun tab_nodes_to_tables/1, TableNodesVariants),
+    SharedTables = ordsets:intersection(TableVariants),
+    AllTables = ordsets:union(TableVariants),
+    ordsets:subtract(AllTables, SharedTables).
+
+-spec tab_nodes_to_tables([tab_nodes()]) -> [table_name()].
+tab_nodes_to_tables(TabNodes) ->
+    [Table || {Table, [_ | _] = _Nodes} <- TabNodes].
+
+%% Returns nodes for each table hosted on node()
+-spec node_list_for_tables_from_disco(node(), disco_name()) -> [tab_nodes()].
+node_list_for_tables_from_disco(Node, Disco) ->
+    Tables = get_tables_list_on_node(Node, Disco),
+    node_list_for_tables(Node, Tables).
+
+%% Returns nodes for each table in the Tables list
+-spec node_list_for_tables(node(), [table_name()]) -> [tab_nodes()].
+node_list_for_tables(Node, Tables) ->
+    [{Table, node_list_for_table(Node, Table)} || Table <- Tables].
+
+-spec get_tables_list_on_node(Node :: node(), Disco :: disco_name()) -> [table_name()].
+get_tables_list_on_node(Node, Disco) ->
+    case rpc:call(Node, cets_discovery, get_tables, [Disco]) of
+        {ok, Tables} ->
+            Tables;
+        _ ->
+            []
+    end.
+
+-spec node_list_for_table(Node :: node(), Table :: table_name()) ->
+    Nodes :: ordsets:ordset(node()).
+node_list_for_table(Node, Table) ->
+    case catch rpc:call(Node, cets, other_nodes, [Table]) of
+        List when is_list(List) ->
+            ordsets:add_element(Node, List);
+        Other ->
+            ?LOG_ERROR(#{
+                what => cets_get_other_nodes_failed, node => Node, table => Table, reason => Other
+            }),
+            []
+    end.
+
+-spec discovery_works(cets_discovery:system_info()) -> boolean().
+discovery_works(#{last_get_nodes_result := {ok, _}}) ->
+    true;
+discovery_works(_) ->
+    false.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -84,6 +84,14 @@ cases() ->
         disco_retried_if_get_nodes_fail,
         disco_uses_regular_retry_interval_in_the_regular_phase,
         disco_handles_node_up_and_down,
+        status_available_nodes,
+        status_available_nodes_do_not_contain_nodes_with_stopped_disco,
+        status_unavailable_nodes,
+        status_remote_nodes_without_disco,
+        status_joined_nodes,
+        status_remote_nodes_with_unknown_tables,
+        status_discovery_works,
+        status_conflict_nodes,
         test_locally,
         handle_down_is_called,
         events_are_applied_in_the_correct_order_after_unpause,
@@ -975,6 +983,173 @@ disco_handles_node_up_and_down(Config) ->
     %% Check that wait_for_ready still works
     ok = cets_discovery:wait_for_ready(Disco, 5000).
 
+status_available_nodes(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, []}, State}
+    end,
+    DiscoName = disco_name(Config),
+    start_disco(Node1, #{name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    start_disco(Node2, #{name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    ?assertMatch(#{available_nodes := [Node1, Node2]}, cets_status:status(DiscoName)).
+
+status_available_nodes_do_not_contain_nodes_with_stopped_disco(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    start_disco(Node1, #{name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    %% Disco not running
+    ?assertMatch(#{available_nodes := [Node1]}, cets_status:status(DiscoName)).
+
+status_unavailable_nodes(Config) ->
+    Node1 = node(),
+    F = fun(State) ->
+        {{ok, [Node1, 'badnode@localhost']}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    %% Disco needs at least one table to start calling get_nodes function
+    Tab = make_name(Config),
+    {ok, _} = start(Node1, Tab),
+    cets_discovery:add_table(Disco, Tab),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    ?assertMatch(#{unavailable_nodes := ['badnode@localhost']}, cets_status:status(DiscoName)).
+
+status_remote_nodes_without_disco(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Tab = make_name(Config),
+    {ok, _} = start(Node1, Tab),
+    cets_discovery:add_table(Disco, Tab),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    ?assertMatch(#{remote_nodes_without_disco := [Node2]}, cets_status:status(DiscoName)).
+
+status_joined_nodes(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco1 = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Disco2 = start_disco(Node2, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Tab = make_name(Config),
+    {ok, _} = start(Node1, Tab),
+    {ok, _} = start(Node2, Tab),
+    %% Add table using pids (i.e. no need to do RPCs here)
+    cets_discovery:add_table(Disco1, Tab),
+    cets_discovery:add_table(Disco2, Tab),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    cets_test_wait:wait_until(fun() -> maps:get(joined_nodes, cets_status:status(DiscoName)) end, [
+        Node1, Node2
+    ]).
+
+status_remote_nodes_with_unknown_tables(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco1 = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Disco2 = start_disco(Node2, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Tab1 = make_name(Config, 1),
+    Tab2 = make_name(Config, 2),
+    %% Node1 does not have Tab2
+    {ok, _} = start(Node1, Tab2),
+    {ok, _} = start(Node2, Tab1),
+    {ok, _} = start(Node2, Tab2),
+    %% Add table using pids (i.e. no need to do RPCs here)
+    cets_discovery:add_table(Disco1, Tab1),
+    cets_discovery:add_table(Disco2, Tab1),
+    cets_discovery:add_table(Disco2, Tab2),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    cets_test_wait:wait_until(
+        fun() -> maps:get(remote_nodes_with_unknown_tables, cets_status:status(DiscoName)) end, [
+            Node2
+        ]
+    ),
+    cets_test_wait:wait_until(
+        fun() -> maps:get(remote_unknown_tables, cets_status:status(DiscoName)) end, [
+            Tab2
+        ]
+    ).
+
+status_conflict_nodes(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco1 = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Disco2 = start_disco(Node2, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Tab1 = make_name(Config, 1),
+    Tab2 = make_name(Config, 2),
+    {ok, _} = start(Node1, Tab1),
+    {ok, _} = start(Node1, Tab2),
+    {ok, _} = start(Node2, Tab1),
+    {ok, Pid22} = start(Node2, Tab2),
+    cets_discovery:add_table(Disco1, Tab1),
+    cets_discovery:add_table(Disco1, Tab2),
+    cets_discovery:add_table(Disco2, Tab1),
+    cets_discovery:add_table(Disco2, Tab2),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    set_other_servers(Pid22, []),
+    cets_test_wait:wait_until(
+        fun() -> maps:get(conflict_nodes, cets_status:status(DiscoName)) end, [Node2]
+    ),
+    cets_test_wait:wait_until(
+        fun() -> maps:get(conflict_tables, cets_status:status(DiscoName)) end, [Tab2]
+    ).
+
+status_discovery_works(Config) ->
+    Node1 = node(),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco1 = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Disco2 = start_disco(Node2, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    Tab = make_name(Config),
+    {ok, _} = start(Node1, Tab),
+    {ok, _} = start(Node2, Tab),
+    %% Add table using pids (i.e. no need to do RPCs here)
+    cets_discovery:add_table(Disco1, Tab),
+    cets_discovery:add_table(Disco2, Tab),
+    ok = cets_discovery:wait_for_ready(DiscoName, 5000),
+    ?assertMatch(#{discovery_works := true}, cets_status:status(DiscoName)).
+
 test_locally(Config) ->
     #{tabs := [T1, T2]} = given_two_joined_tables(Config),
     cets:insert(T1, {1}),
@@ -1451,6 +1626,11 @@ start(Node, Tab) ->
     schedule_cleanup(Pid),
     {ok, Pid}.
 
+start_disco(Node, Opts) ->
+    {ok, Pid} = rpc(Node, cets_discovery, start, [Opts]),
+    schedule_cleanup(Pid),
+    Pid.
+
 insert(Node, Tab, Rec) ->
     rpc(Node, cets, insert, [Tab, Rec]).
 
@@ -1517,6 +1697,10 @@ make_name(Config, Num) ->
 lock_name(Config) ->
     Testcase = proplists:get_value(testcase, Config),
     list_to_atom(atom_to_list(Testcase) ++ "_lock").
+
+disco_name(Config) ->
+    Testcase = proplists:get_value(testcase, Config),
+    list_to_atom(atom_to_list(Testcase) ++ "_disco").
 
 count_remote_ops_in_the_message_box(Pid) ->
     {messages, Messages} = erlang:process_info(Pid, messages),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -76,6 +76,7 @@ cases() ->
         node_list_is_correct,
         test_multinode_auto_discovery,
         test_disco_add_table,
+        test_disco_delete_table,
         test_disco_file_appears,
         test_disco_handles_bad_node,
         cets_discovery_fun_backend_works,
@@ -808,6 +809,15 @@ test_disco_add_table(Config) ->
     [#{memory := _, nodes := [Node1, Node2], size := 0, table := Tab}] =
         cets_discovery:info(Disco),
     ok.
+
+test_disco_delete_table(Config) ->
+    F = fun(State) -> {{ok, []}, State} end,
+    {ok, Disco} = cets_discovery:start(#{backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    Tab = make_name(Config),
+    cets_discovery:add_table(Disco, Tab),
+    #{tables := [Tab]} = cets_discovery:system_info(Disco),
+    cets_discovery:delete_table(Disco, Tab),
+    #{tables := []} = cets_discovery:system_info(Disco).
 
 test_disco_file_appears(Config) ->
     Node1 = node(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -77,6 +77,8 @@ cases() ->
         test_multinode_auto_discovery,
         test_disco_add_table,
         test_disco_delete_table,
+        test_disco_delete_unknown_table,
+        test_disco_delete_table_twice,
         test_disco_file_appears,
         test_disco_handles_bad_node,
         cets_discovery_fun_backend_works,
@@ -819,6 +821,23 @@ test_disco_delete_table(Config) ->
     Tab = make_name(Config),
     cets_discovery:add_table(Disco, Tab),
     #{tables := [Tab]} = cets_discovery:system_info(Disco),
+    cets_discovery:delete_table(Disco, Tab),
+    #{tables := []} = cets_discovery:system_info(Disco).
+
+test_disco_delete_unknown_table(Config) ->
+    F = fun(State) -> {{ok, []}, State} end,
+    {ok, Disco} = cets_discovery:start(#{backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    Tab = make_name(Config),
+    cets_discovery:delete_table(Disco, Tab),
+    #{tables := []} = cets_discovery:system_info(Disco).
+
+test_disco_delete_table_twice(Config) ->
+    F = fun(State) -> {{ok, []}, State} end,
+    {ok, Disco} = cets_discovery:start(#{backend_module => cets_discovery_fun, get_nodes_fn => F}),
+    Tab = make_name(Config),
+    cets_discovery:add_table(Disco, Tab),
+    #{tables := [Tab]} = cets_discovery:system_info(Disco),
+    cets_discovery:delete_table(Disco, Tab),
     cets_discovery:delete_table(Disco, Tab),
     #{tables := []} = cets_discovery:system_info(Disco).
 


### PR DESCRIPTION
Add cets_status module

The code gets a list of nodes, gets a list of servers and compares them.
After that it produces a map like:

```erlang
-type info() :: #{
    %% Nodes that are connected to us and have the CETS disco process started.
    available_nodes := [node()],
    %% Nodes that do not respond to our pings.
    unavailable_nodes := [node()],
    %% Nodes with stopped disco
    remote_nodes_without_disco := [node()],
    %% Nodes that has our local tables running (but could also have some unknown tables).
    %% All joined nodes replicate data between each other.
    joined_nodes := [node()],
    %% Nodes that have more tables registered than the local node.
    remote_nodes_with_unknown_tables := [node()],
    remote_unknown_tables := [table_name()],
    %% Nodes that are available, but do not host one of our local tables.
    remote_nodes_with_missing_tables => [node()],
    remote_missing_tables := [table_name()],
    %% Nodes that replicate at least one of our local tables to a different list of nodes
    %% (could temporary happen during a netsplit)
    conflict_nodes := [node()],
    conflict_tables := [table_name()],
    %% Nodes that are extracted from the discovery backend.
    discovered_nodes := [node()],
    %% True, if discovery backend returned the list of nodes the last time we've tried
    %% to call it.
    discovery_works := boolean()
}.
```

The map could be used for getting the status of the cluster.

This functionality is used in MongooseIM like that https://github.com/esl/MongooseIM/pull/4116