### PR TITLE
Add cets:insert_serial/2

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -259,7 +259,7 @@ handle_insert_new_result({error, rejected}) -> false.
 %% It could be used to update entries, which use not node-specific keys.
 -spec insert_serial(server_ref(), tuple()) -> ok.
 insert_serial(Server, Rec) when is_tuple(Rec) ->
-    ok = cets_call:send_leader_op(Server, {insert, Rec}).
+    ok = cets_call:send_leader_op(Server, {leader_op, {insert, Rec}}).
 
 %% Removes an object with the key from all nodes in the cluster.
 %% Ideally, nodes should only remove data that they've inserted, not data from other node.
@@ -611,6 +611,8 @@ handle_leader_op(Op, From, State = #{is_leader := true}) ->
             gen_server:reply(From, {error, rejected}),
             ok;
         true ->
+            replicate(Op, From, State);
+        ok ->
             replicate(Op, From, State)
     end;
 handle_leader_op(Op, From, State = #{leader := Leader}) ->

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -245,7 +245,7 @@ insert_many(Server, Records) when is_list(Records) ->
 %% extra messaging is required.
 -spec insert_new(server_ref(), tuple()) -> WasInserted :: boolean().
 insert_new(Server, Rec) when is_tuple(Rec) ->
-    Res = cets_call:send_leader_op(Server, {leader_op, {insert_new, Rec}}),
+    Res = cets_call:send_leader_op(Server, {insert_new, Rec}),
     handle_insert_new_result(Res).
 
 handle_insert_new_result(ok) -> true;
@@ -259,7 +259,7 @@ handle_insert_new_result({error, rejected}) -> false.
 %% It could be used to update entries, which use not node-specific keys.
 -spec insert_serial(server_ref(), tuple()) -> ok.
 insert_serial(Server, Rec) when is_tuple(Rec) ->
-    ok = cets_call:send_leader_op(Server, {leader_op, {insert, Rec}}).
+    ok = cets_call:send_leader_op(Server, {insert, Rec}).
 
 %% Removes an object with the key from all nodes in the cluster.
 %% Ideally, nodes should only remove data that they've inserted, not data from other node.

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -70,7 +70,7 @@ send_leader_op(Server, Op) ->
 
 send_leader_op(Server, Op, Backoff) ->
     Leader = cets:get_leader(Server),
-    Res = maybe_sync_operation(Leader, {leader_op, Op}),
+    Res = maybe_sync_operation(Leader, Op),
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
             ?LOG_WARNING(#{

--- a/src/cets_call.erl
+++ b/src/cets_call.erl
@@ -70,7 +70,7 @@ send_leader_op(Server, Op) ->
 
 send_leader_op(Server, Op, Backoff) ->
     Leader = cets:get_leader(Server),
-    Res = maybe_sync_operation(Leader, Op),
+    Res = maybe_sync_operation(Leader, {leader_op, Op}),
     case Res of
         {error, {wrong_leader, ExpectedLeader}} ->
             ?LOG_WARNING(#{

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -56,6 +56,8 @@ cases() ->
         insert_new_is_retried_when_leader_is_reelected,
         insert_new_fails_if_the_leader_dies,
         insert_new_fails_if_the_local_server_is_dead,
+        insert_serial_works,
+        insert_serial_overwrites_data,
         leader_is_the_same_in_metadata_after_join,
         join_with_the_same_pid,
         join_ref_is_same_after_join,
@@ -380,6 +382,19 @@ insert_new_fails_if_the_local_server_is_dead(_Config) ->
     catch
         exit:{noproc, {gen_server, call, _}} -> ok
     end.
+
+insert_serial_works(Config) ->
+    #{pid1 := Pid1, tab1 := Tab1, tab2 := Tab2} = given_two_joined_tables(Config),
+    ok = cets:insert_serial(Pid1, {a, 1}),
+    [{a, 1}] = cets:dump(Tab1),
+    [{a, 1}] = cets:dump(Tab2).
+
+insert_serial_overwrites_data(Config) ->
+    #{pid1 := Pid1, tab1 := Tab1, tab2 := Tab2} = given_two_joined_tables(Config),
+    ok = cets:insert_serial(Pid1, {a, 1}),
+    ok = cets:insert_serial(Pid1, {a, 2}),
+    [{a, 2}] = cets:dump(Tab1),
+    [{a, 2}] = cets:dump(Tab2).
 
 leader_is_the_same_in_metadata_after_join(Config) ->
     #{tabs := [T1, T2], pids := [Pid1, Pid2]} = given_two_joined_tables(Config),


### PR DESCRIPTION
All `insert_serial' calls are sent to the leader node first.

Similar to `insert_new/2`, but overwrites the data silently on conflict.
 It could be used to update entries, which use not node-specific keys.
 
 This function ensures that all nodes would agree on the value, if they try to insert (OR overwrite) a record with the same key at once.
 
 It is used by https://github.com/esl/MongooseIM/pull/4136