### PR TITLE
Ensure that unavailable_nodes list is a subset of discovered_nodes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,8 @@
     ]},
     {test, [
         {deps, [
-            {logger_debug_h, "0.1.0"}
+            {logger_debug_h, "0.1.0"},
+            {meck, "0.9.2"}
         ]},
         {plugins, [
             {rebar3_codecov, "0.6.0"}

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -1091,12 +1091,11 @@ status_joined_nodes(Config) ->
         {{ok, [Node1, Node2]}, State}
     end,
     DiscoName = disco_name(Config),
-    Disco1 = start_disco(Node1, #{
+    DiscoOpts = #{
         name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
-    Disco2 = start_disco(Node2, #{
-        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
+    },
+    Disco1 = start_disco(Node1, DiscoOpts),
+    Disco2 = start_disco(Node2, DiscoOpts),
     Tab = make_name(Config),
     {ok, _} = start(Node1, Tab),
     {ok, _} = start(Node2, Tab),
@@ -1115,12 +1114,11 @@ status_discovery_works(Config) ->
         {{ok, [Node1, Node2]}, State}
     end,
     DiscoName = disco_name(Config),
-    Disco1 = start_disco(Node1, #{
+    DiscoOpts = #{
         name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
-    Disco2 = start_disco(Node2, #{
-        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
+    },
+    Disco1 = start_disco(Node1, DiscoOpts),
+    Disco2 = start_disco(Node2, DiscoOpts),
     Tab = make_name(Config),
     {ok, _} = start(Node1, Tab),
     {ok, _} = start(Node2, Tab),
@@ -1171,12 +1169,11 @@ status_remote_nodes_with_unknown_tables(Config) ->
         {{ok, [Node1, Node2]}, State}
     end,
     DiscoName = disco_name(Config),
-    Disco1 = start_disco(Node1, #{
+    DiscoOpts = #{
         name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
-    Disco2 = start_disco(Node2, #{
-        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
+    },
+    Disco1 = start_disco(Node1, DiscoOpts),
+    Disco2 = start_disco(Node2, DiscoOpts),
     Tab1 = make_name(Config, 1),
     Tab2 = make_name(Config, 2),
     %% Node1 does not have Tab2
@@ -1206,12 +1203,11 @@ status_remote_nodes_with_missing_nodes(Config) ->
         {{ok, [Node1, Node2]}, State}
     end,
     DiscoName = disco_name(Config),
-    Disco1 = start_disco(Node1, #{
+    DiscoOpts = #{
         name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
-    Disco2 = start_disco(Node2, #{
-        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
+    },
+    Disco1 = start_disco(Node1, DiscoOpts),
+    Disco2 = start_disco(Node2, DiscoOpts),
     Tab1 = make_name(Config, 1),
     Tab2 = make_name(Config, 2),
     %% Node2 does not have Tab2
@@ -1240,12 +1236,11 @@ status_conflict_nodes(Config) ->
         {{ok, [Node1, Node2]}, State}
     end,
     DiscoName = disco_name(Config),
-    Disco1 = start_disco(Node1, #{
+    DiscoOpts = #{
         name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
-    Disco2 = start_disco(Node2, #{
-        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
-    }),
+    },
+    Disco1 = start_disco(Node1, DiscoOpts),
+    Disco2 = start_disco(Node2, DiscoOpts),
     Tab1 = make_name(Config, 1),
     Tab2 = make_name(Config, 2),
     {ok, _} = start(Node1, Tab1),


### PR DESCRIPTION
Addresses "MIM-2054 CETS status: removed nodes from disco should not be listed in a list of unavailable nodes"

Changes:
- Ensure that unavailable_nodes list is a subset of discovered_nodes
- Add status_discovered_nodes testcase (a test  for this field was missing)
- Use ordsets in types for nodes (because they are ordsets)
- Define `DiscoOpts` in tests instead of constructing the same map twice (small refactoring)


Nodes could be removed from the discovery_nodes table after some time.
After that point, the removed node should not appear in the systemInfo API.
But we currently we can have:

```json
./_build/mim1/rel/mongooseim/bin/mongooseimctl cets systemInfo
{
  "data" : {
    "cets" : {
      "systemInfo" : {
        "unavailableNodes" : [
          "badnode@localhost"
        ],
        "discoveredNodes" : [
          "mongooseim2@localhost",
          "mongooseim3@localhost",
          "mongooseim@localhost"
        ],
        "availableNodes" : [
          "mongooseim@localhost",
          "mongooseim2@localhost",
          "mongooseim3@localhost"
        ]
        ....
```

We need to ensure that unavailableNodes is a subset of discoveredNodes before returning it to the user.