### PR TITLE
Add insert_new_or_lookup/2 function

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -23,6 +23,7 @@
     insert/2,
     insert_many/2,
     insert_new/2,
+    insert_new_or_read/2,
     insert_serial/2,
     delete/2,
     delete_many/2,
@@ -64,6 +65,7 @@
     insert/2,
     insert_many/2,
     insert_new/2,
+    insert_new_or_read/2,
     insert_serial/2,
     delete/2,
     delete_many/2,
@@ -109,6 +111,7 @@
     | {delete_many, [term()]}
     | {delete_objects, [term()]}
     | {insert_new, tuple()}
+    | {insert_new_or_read, tuple()}
     | {leader_op, op()}.
 -type remote_op() ::
     {remote_op, Op :: op(), From :: from(), AckPid :: ack_pid(), JoinRef :: join_ref()}.
@@ -118,6 +121,7 @@
 -type servers() :: ordsets:ordset(server_pid()).
 -type state() :: #{
     tab := table_name(),
+    keypos := pos_integer(),
     ack_pid := ack_pid(),
     join_ref := join_ref(),
     %% Updated by set_other_servers/2 function only
@@ -250,6 +254,22 @@ insert_new(Server, Rec) when is_tuple(Rec) ->
 
 handle_insert_new_result(ok) -> true;
 handle_insert_new_result({error, rejected}) -> false.
+
+%% Sometimes we want to insert_new or return an existing record.
+%% This would require a retry mechanism coded each time in the client code.
+%% This function asks the server to return the existing record, so the usage
+%% could be simplified
+-spec insert_new_or_read(server_ref(), tuple()) -> {WasInserted, ReadRecords} when
+    WasInserted :: boolean(),
+    ReadRecords :: [tuple()].
+insert_new_or_read(Server, Rec) when is_tuple(Rec) ->
+    Res = cets_call:send_leader_op(Server, {insert_new_or_read, Rec}),
+    handle_insert_new_or_read(Res, Rec).
+
+handle_insert_new_or_read(ok, Rec) ->
+    {true, [Rec]};
+handle_insert_new_or_read({error, {rejected, Recs}}, _CandidateRec) ->
+    {false, Recs}.
 
 %% @doc Serialized version of `insert/2'.
 %%
@@ -388,6 +408,7 @@ init({Tab, Opts}) ->
     {ok, AckPid} = cets_ack:start_link(Tab),
     {ok, #{
         tab => Tab,
+        keypos => KeyPos,
         ack_pid => AckPid,
         other_servers => [],
         %% Initial join_ref is random
@@ -595,6 +616,8 @@ do_table_op({delete_many, Keys}, Tab) ->
 do_table_op({delete_objects, Objects}, Tab) ->
     ets_delete_objects(Tab, Objects);
 do_table_op({insert_new, Rec}, Tab) ->
+    ets:insert_new(Tab, Rec);
+do_table_op({insert_new_or_read, Rec}, Tab) ->
     ets:insert_new(Tab, Rec).
 
 %% Handle operation locally and replicate it across the cluster
@@ -605,12 +628,21 @@ handle_op(Op, From, State) ->
     do_op(Op, State),
     replicate(Op, From, State).
 
+-spec rejected_result(op(), state()) -> term().
+rejected_result({insert_new, _Rec}, _State) ->
+    {error, rejected};
+rejected_result({insert_new_or_read, Rec}, #{keypos := KeyPos, tab := Tab}) ->
+    Key = element(KeyPos, Rec),
+    %% Return a list of records, because the table could be a bag
+    Recs = ets:lookup(Tab, Key),
+    {error, {rejected, Recs}}.
+
 -spec handle_leader_op(op(), from(), state()) -> ok.
 handle_leader_op(Op, From, State = #{is_leader := true}) ->
     case do_op(Op, State) of
         %% Skip the replication - insert_new returns false.
         false ->
-            gen_server:reply(From, {error, rejected}),
+            gen_server:reply(From, rejected_result(Op, State)),
             ok;
         true ->
             replicate(Op, From, State)

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -56,7 +56,7 @@ cases() ->
         insert_new_is_retried_when_leader_is_reelected,
         insert_new_fails_if_the_leader_dies,
         insert_new_fails_if_the_local_server_is_dead,
-        insert_new_or_read_works,
+        insert_new_or_lookup_works,
         insert_serial_works,
         insert_serial_overwrites_data,
         insert_overwrites_data_inconsistently,
@@ -389,16 +389,16 @@ insert_new_fails_if_the_local_server_is_dead(_Config) ->
         exit:{noproc, {gen_server, call, _}} -> ok
     end.
 
-insert_new_or_read_works(Config) ->
+insert_new_or_lookup_works(Config) ->
     #{pid1 := Pid1, pid2 := Pid2} = given_two_joined_tables(Config),
     Rec1 = {alice, 32},
     Rec2 = {alice, 33},
-    {true, [Rec1]} = cets:insert_new_or_read(Pid1, Rec1),
+    {true, [Rec1]} = cets:insert_new_or_lookup(Pid1, Rec1),
     %% Duplicate found
-    {false, [Rec1]} = cets:insert_new_or_read(Pid1, Rec1),
-    {false, [Rec1]} = cets:insert_new_or_read(Pid2, Rec1),
-    {false, [Rec1]} = cets:insert_new_or_read(Pid1, Rec2),
-    {false, [Rec1]} = cets:insert_new_or_read(Pid2, Rec2).
+    {false, [Rec1]} = cets:insert_new_or_lookup(Pid1, Rec1),
+    {false, [Rec1]} = cets:insert_new_or_lookup(Pid2, Rec1),
+    {false, [Rec1]} = cets:insert_new_or_lookup(Pid1, Rec2),
+    {false, [Rec1]} = cets:insert_new_or_lookup(Pid2, Rec2).
 
 insert_serial_works(Config) ->
     #{pid1 := Pid1, tab1 := Tab1, tab2 := Tab2} = given_two_joined_tables(Config),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -56,6 +56,7 @@ cases() ->
         insert_new_is_retried_when_leader_is_reelected,
         insert_new_fails_if_the_leader_dies,
         insert_new_fails_if_the_local_server_is_dead,
+        insert_new_or_read_works,
         insert_serial_works,
         insert_serial_overwrites_data,
         insert_overwrites_data_inconsistently,
@@ -387,6 +388,17 @@ insert_new_fails_if_the_local_server_is_dead(_Config) ->
     catch
         exit:{noproc, {gen_server, call, _}} -> ok
     end.
+
+insert_new_or_read_works(Config) ->
+    #{pid1 := Pid1, pid2 := Pid2} = given_two_joined_tables(Config),
+    Rec1 = {alice, 32},
+    Rec2 = {alice, 33},
+    {true, [Rec1]} = cets:insert_new_or_read(Pid1, Rec1),
+    %% Duplicate found
+    {false, [Rec1]} = cets:insert_new_or_read(Pid1, Rec1),
+    {false, [Rec1]} = cets:insert_new_or_read(Pid2, Rec1),
+    {false, [Rec1]} = cets:insert_new_or_read(Pid1, Rec2),
+    {false, [Rec1]} = cets:insert_new_or_read(Pid2, Rec2).
 
 insert_serial_works(Config) ->
     #{pid1 := Pid1, tab1 := Tab1, tab2 := Tab2} = given_two_joined_tables(Config),


### PR DESCRIPTION
`insert_new/2` is useful, but there could be a case, when we want to insert new or read existing record.
And there could be a race condition between these two events (i.e. this race condition is even in the default ets module).
Which means the code would have to implement this:

```erlang
-spec init_ram_key(ProposedKey) -> Result when
      ProposedKey :: mod_keystore:key(),
      Result :: {ok, ActualKey} | {error, init_ram_key_failed},
      ActualKey :: mod_keystore:key().
init_ram_key(ProposedKey) ->
    init_ram_key(ProposedKey, 1, 3).

%% Inserts new key or returns already inserted.
-spec init_ram_key(Key, TriedTimes, Retries) -> Result when
      Result :: {ok, Key} | {error, init_ram_key_failed},
      Key :: mod_keystore:key(),
      TriedTimes :: non_neg_integer(),
      Retries :: non_neg_integer().
init_ram_key(#key{id = Id, key = Key}, _, 0) ->
    ?LOG_ERROR(#{what => init_ram_key_failed, id => Id, key => Key}),
    {error, init_ram_key_failed};
init_ram_key(ProposedKey = #key{id = Id = {_, HostType}, key = PropKey}, N, Retries) ->
    Tab = table_name(HostType),
    case cets:insert_new(Tab, {Id, PropKey}) of
        true ->
            {ok, ProposedKey};
        false ->
            case ets:lookup(Tab, Id) of
                [{Id, Key}] ->
                    %% Return already inserted key
                    {ok, #key{id = Id, key = Key}};
                [] ->
                    ?LOG_WARNING(#{what => init_ram_key_retry,
                                   id => Id, key => PropKey, tried_times => N}),
                    init_ram_key(ProposedKey, N + 1, Retries - 1)
            end
   end.
 ```
 
 Retry mechanism. Would also require tests, would also need to decide when to stop to retry... Sounds too much work.
 
 This new function allows to rewrite the above code as:
 
 ```erlang
-spec init_ram_key(ProposedKey) -> Result when
      ProposedKey :: mod_keystore:key(),
      Result :: {ok, ActualKey} | {error, init_ram_key_failed},
      ActualKey :: mod_keystore:key().
init_ram_key(ProposedKey = #key{id = Id = {_, HostType}, key = PropKey}) ->
    Tab = table_name(HostType),
    case cets:insert_new_or_lookup(Tab, {Id, PropKey}) of
        {true, _} ->
            {ok, ProposedKey};
        {false, [{Id, Key}]} ->
            {ok, #key{id = Id, key = Key}}
   end.
 ```
 
 It is in case you want to write a testcase for the false condition. If you don't want to have any special logic in case of conflict (and no separation in the cover reports):
 
  ```erlang
-spec init_ram_key(ProposedKey) -> Result when
      ProposedKey :: mod_keystore:key(),
      Result :: {ok, ActualKey} | {error, init_ram_key_failed},
      ActualKey :: mod_keystore:key().
init_ram_key(ProposedKey = #key{id = Id = {_, HostType}, key = PropKey}) ->
    Tab = table_name(HostType),
    {_, [{Id, Key}]} = cets:insert_new_or_lookup(Tab, {Id, PropKey}),
    {ok, #key{id = Id, key = Key}}.
 ```