### PR TITLE
Fix never returning gen_server:call(Server, sync) call

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -40,7 +40,7 @@
     unpause/2,
     get_leader/1,
     set_leader/2,
-    sync/1,
+    ping_all/1,
     ping/1,
     info/1,
     insert_request/2,
@@ -75,7 +75,7 @@
     unpause/2,
     get_leader/1,
     set_leader/2,
-    sync/1,
+    ping_all/1,
     ping/1,
     info/1,
     other_nodes/1,
@@ -137,7 +137,7 @@
     pause
     | ping
     | remote_dump
-    | sync
+    | ping_all
     | table_name
     | get_info
     | other_servers
@@ -382,9 +382,9 @@ set_leader(Server, IsLeader) ->
     cets_call:long_call(Server, {set_leader, IsLeader}).
 
 %% Waits till all pending operations are applied.
--spec sync(server_ref()) -> ok.
-sync(Server) ->
-    cets_call:long_call(Server, sync).
+-spec ping_all(server_ref()) -> ok | {error, [{server_pid(), Reason :: term()}]}.
+ping_all(Server) ->
+    cets_call:long_call(Server, ping_all).
 
 -spec ping(server_ref()) -> pong.
 ping(Server) ->
@@ -435,13 +435,19 @@ handle_call(get_nodes, _From, State = #{other_servers := Servers}) ->
     {reply, lists:usort([node() | pids_to_nodes(Servers)]), State};
 handle_call(get_leader, _From, State = #{leader := Leader}) ->
     {reply, Leader, State};
-handle_call(sync, From, State = #{other_servers := Servers}) ->
+handle_call(ping_all, From, State = #{other_servers := Servers}) ->
     %% Do spawn to avoid any possible deadlocks
     proc_lib:spawn(fun() ->
         %% If ping crashes, the caller would not receive a reply.
         %% So, we have to use catch to still able to reply with ok.
-        lists:foreach(fun(Server) -> catch ping(Server) end, Servers),
-        gen_server:reply(From, ok)
+        Results = lists:map(fun(Server) -> {Server, catch ping(Server)} end, Servers),
+        BadResults = [Res || {_Server, Result} = Res <- Results, Result =/= pong],
+        case BadResults of
+            [] ->
+                gen_server:reply(From, ok);
+            _ ->
+                gen_server:reply(From, {error, BadResults})
+        end
     end),
     {noreply, State};
 handle_call(ping, _From, State) ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2192,7 +2192,8 @@ cets_ping_all_returns_when_ping_crashes(Config) ->
         (Server, ping) when Server == Pid2 -> error(simulate_crash);
         (Server, Msg) -> meck:passthrough([Server, Msg])
     end),
-    ?assertMatch({error, [{Pid2, {'EXIT', {simulate_crash, _}}}]}, cets:ping_all(Pid1)).
+    ?assertMatch({error, [{Pid2, {'EXIT', {simulate_crash, _}}}]}, cets:ping_all(Pid1)),
+    meck:unload().
 
 join_interrupted_when_ping_crashes(Config) ->
     #{pid1 := Pid1, pid2 := Pid2} = given_two_joined_tables(Config),
@@ -2203,7 +2204,8 @@ join_interrupted_when_ping_crashes(Config) ->
         (Server, ping) when Server == Pid2 -> error(simulate_crash);
         (Server, Msg) -> meck:passthrough([Server, Msg])
     end),
-    ?assertMatch({error, ping_all_failed}, cets_join:join(lock_name(Config), #{}, Pid1, Pid3)).
+    ?assertMatch({error, ping_all_failed}, cets_join:join(lock_name(Config), #{}, Pid1, Pid3)),
+    meck:unload().
 
 %% Helper functions
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2203,7 +2203,8 @@ join_interrupted_when_ping_crashes(Config) ->
         (Server, ping) when Server == Pid2 -> error(simulate_crash);
         (Server, Msg) -> meck:passthrough([Server, Msg])
     end),
-    ?assertMatch({error, ping_all_failed}, cets_join:join(lock_name(Config), #{}, Pid1, Pid3)),
+    Res = cets_join:join(lock_name(Config), #{}, Pid1, Pid3),
+    ?assertMatch({error, {task_failed, ping_all_failed, #{}}}, Res),
     meck:unload().
 
 %% Helper functions

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -18,7 +18,8 @@ all() ->
         %% To improve the code coverage we need to test with logging disabled
         %% More info: https://github.com/erlang/otp/issues/7531
         {group, cets_no_log},
-        {group, cets_seq}
+        {group, cets_seq},
+        {group, cets_seq_no_log}
     ].
 
 groups() ->
@@ -29,7 +30,8 @@ groups() ->
         %% Though, global's prevent_overlapping_partitions option starts kicking
         %% all nodes from the cluster, so we have to be careful not to break other cases.
         %% Setting prevent_overlapping_partitions=false on ct5 helps.
-        {cets_seq, [sequence, {repeat_until_any_fail, 2}], seq_cases()}
+        {cets_seq, [sequence, {repeat_until_any_fail, 2}], seq_cases()},
+        {cets_seq_no_log, [sequence, {repeat_until_any_fail, 2}], cets_seq_no_log_cases()}
     ].
 
 cases() ->
@@ -168,14 +170,15 @@ seq_cases() ->
         disco_connects_to_unconnected_node,
         joining_not_fully_connected_node_is_not_allowed,
         joining_not_fully_connected_node_is_not_allowed2,
-<<<<<<< HEAD
         %% Cannot be run in parallel with other tests because checks all logging messages.
         logging_when_failing_join_with_disco,
-        cets_sync_returns_when_ping_crashes
-=======
         cets_ping_all_returns_when_ping_crashes,
         join_interrupted_when_ping_crashes
->>>>>>> e511cb6 (Rename cets:sync to cets:ping_all)
+    ].
+
+cets_seq_no_log_cases() ->
+    [
+        join_interrupted_when_ping_crashes
     ].
 
 init_per_suite(Config) ->
@@ -190,13 +193,13 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-init_per_group(cets_no_log, Config) ->
+init_per_group(Group, Config) when Group == cets_seq_no_log; Group == cets_no_log ->
     [ok = logger:set_module_level(M, none) || M <- log_modules()],
     Config;
 init_per_group(_Group, Config) ->
     Config.
 
-end_per_group(cets_no_log, Config) ->
+end_per_group(Group, Config) when Group == cets_seq_no_log; Group == cets_no_log ->
     [ok = logger:unset_module_level(M) || M <- log_modules()],
     Config;
 end_per_group(_Group, Config) ->
@@ -2127,7 +2130,6 @@ joining_not_fully_connected_node_is_not_allowed2(Config) ->
     end,
     [] = cets:other_pids(Pid5).
 
-<<<<<<< HEAD
 logging_when_failing_join_with_disco(Config) ->
     %% Simulate cets:other_pids/1 failing with reason:
     %%  {{nodedown,'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'},
@@ -2182,10 +2184,7 @@ logging_when_failing_join_with_disco(Config) ->
     end,
     ok.
 
-cets_sync_returns_when_ping_crashes(Config) ->
-=======
 cets_ping_all_returns_when_ping_crashes(Config) ->
->>>>>>> e511cb6 (Rename cets:sync to cets:ping_all)
     #{pid1 := Pid1, pid2 := Pid2} = given_two_joined_tables(Config),
     meck:new(cets, [passthrough]),
     meck:expect(cets_call, long_call, fun


### PR DESCRIPTION
There are some records found in logs at startup:

```erlang
...there are more logs above...
when=2023-10-24T06:22:02.336073+00:00 level=error what=long_task_failed reason={{nodedown,'mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local'},{gen_server,call,[<30886.526.0>,ping,infinity]}} pid=<0.2223.0> at=cets_long:run_tracked/2:63 stacktrace="gen_server:call/3:401 cets_long:run_tracked/2:54 lists:foreach_1/2:1686 cets:'-handle_call/3-fun-1-'/2:441 proc_lib:init_p/3:226" server=<30886.526.0> msg=ping pid=<30886.526.0> node=mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local
...there are more logs here too...
when=2023-10-24T06:22:12.340256+00:00 level=warning what=long_task_progress pid=<0.2222.0> at=cets_long:monitor_loop/5:88 time_ms=10004 server=cets_session msg=sync pid=<0.526.0> node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local current_stacktrace="[{gen,do_call,4,[{file,\"gen.erl\"},{line,240}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,397}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,54}]},{ejabberd_sm_cets,cleanup,1,[{file,\"/home/circleci/project/src/ejabberd_sm_cets.erl\"},{line,79}]},{timer,tc,3,[{file,\"timer.erl\"},{line,295}]},{ejabberd_sm,handle_call,3,[{file,\"/home/circleci/project/src/ejabberd_sm.erl\"},{line,474}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,1113}]},{gen_server,handle_msg,6,[{file,\"gen_server.erl\"},{line,1142}]}]"
when=2023-10-24T06:22:17.342470+00:00 level=warning what=long_task_progress pid=<0.2222.0> at=cets_long:monitor_loop/5:88 time_ms=15006 server=cets_session msg=sync pid=<0.526.0> node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local current_stacktrace="[{gen,do_call,4,[{file,\"gen.erl\"},{line,240}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,397}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,54}]},{ejabberd_sm_cets,cleanup,1,[{file,\"/home/circleci/project/src/ejabberd_sm_cets.erl\"},{line,79}]},{timer,tc,3,[{file,\"timer.erl\"},{line,295}]},{ejabberd_sm,handle_call,3,[{file,\"/home/circleci/project/src/ejabberd_sm.erl\"},{line,474}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,1113}]},{gen_server,handle_msg,6,[{file,\"gen_server.erl\"},{line,1142}]}]"
```

Generally, that nodedown is caused by `global` module doing that:

```erlang
when=2023-10-24T06:22:10.304831+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' requested disconnect from node 'mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local' in order to prevent overlapping partitions"
when=2023-10-24T06:22:10.306128+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' requested disconnect from node 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local' in order to prevent overlapping partitions"
```

But in case global disconnects one of the pinged nodes, `sync` call could crash and never return to the client.

The issue is related to "MIM-2073 Multiple errors in the logs on cluster startup with CETS", but does not fully fixes all the possible errors in MIM-2073. 

So, this PR has a very limited scope:
- Fix never returning sync call
- Ensure that we send the reply to the caller of the sync call 
- Add cets_sync_returns_when_ping_crashes testcase

It does not improve logs or fixes global behaviour - there would be separate PRs for that.