### PR TITLE
Log error once in nested long calls

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,8 +37,7 @@
     ]},
     {test, [
         {deps, [
-            {logger_debug_h,
-                {git, "https://github.com/arcusfelis/logger_debug_h.git", {branch, "main"}}},
+            {logger_debug_h, "0.2.0"},
             {meck, "0.9.2"}
         ]},
         {plugins, [

--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,8 @@
     ]},
     {test, [
         {deps, [
-            {logger_debug_h, "0.1.0"},
+            {logger_debug_h,
+                {git, "https://github.com/arcusfelis/logger_debug_h.git", {branch, "main"}}},
             {meck, "0.9.2"}
         ]},
         {plugins, [

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -58,7 +58,8 @@ run_tracked(Info, Fun) ->
                 what => long_task_failed,
                 class => Class,
                 reason => Reason,
-                stacktrace => Stacktrace
+                stacktrace => Stacktrace,
+                caller_pid => Parent
             },
             ?LOG_ERROR(Log),
             erlang:raise(Class, Reason, Stacktrace)
@@ -79,7 +80,7 @@ run_monitor(Info, Parent, Start) ->
 monitor_loop(Mon, Info, Parent, Start, Interval) ->
     receive
         {'DOWN', MonRef, process, _Pid, Reason} when Mon =:= MonRef ->
-            ?LOG_ERROR(Info#{what => long_task_failed, reason => Reason}),
+            ?LOG_ERROR(Info#{what => long_task_failed, reason => Reason, caller_pid => Parent}),
             ok;
         stop ->
             ok
@@ -87,6 +88,7 @@ monitor_loop(Mon, Info, Parent, Start, Interval) ->
         Diff = diff(Start),
         ?LOG_WARNING(Info#{
             what => long_task_progress,
+            caller_pid => Parent,
             time_ms => Diff,
             current_stacktrace => pinfo(Parent, current_stacktrace)
         }),

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -70,7 +70,8 @@ run_tracked(Info, Fun) ->
     end.
 
 spawn_mon(Info, Parent, Start) ->
-    spawn_link(fun() -> run_monitor(Info, Parent, Start) end).
+    %% We do not link, because we want to log if the Parent dies
+    spawn(fun() -> run_monitor(Info, Parent, Start) end).
 
 run_monitor(Info, Parent, Start) ->
     Mon = erlang:monitor(process, Parent),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2043,7 +2043,9 @@ logging_when_failing_join_with_disco(Config) ->
         %% Only one message is logged
         [_] = MatchedLogs
     after
-        reconnect_node(Node2, Peer2)
+        meck:unload(),
+        reconnect_node(Node2, Peer2),
+        cets:stop(Pid2)
     end,
     ok.
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -23,7 +23,7 @@ all() ->
 
 groups() ->
     [
-        {cets, [parallel, {repeat_until_any_fail, 300}], cases() ++ only_for_logger_cases()},
+        {cets, [parallel, {repeat_until_any_fail, 3}], cases() ++ only_for_logger_cases()},
         {cets_no_log, [parallel], cases()},
         %% These tests actually simulate a netsplit on the distribution level.
         %% Though, global's prevent_overlapping_partitions option starts kicking


### PR DESCRIPTION
The PR reduces the amount of noise reported in "MIM-2073 Multiple errors in the logs on cluster startup with CETS" issue.

Before the same error was reported 3 times from 3 different places (we do over-reporting):

```
when=2023-10-17T19:10:31.083740+00:00 level=error what=long_task_failed reason={{nodedown,'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'},{gen_server,call,[<30887.545.0>,other_servers,infinity]}} pid=<0.567.0> at=cets_long:run_tracked/2:63 stacktrace="gen_server:call/3:401 cets_long:run_tracked/2:54 cets_join:get_pids/1:192 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:check_fully_connected/2:264 cets_join:check_pids/4:199 cets_join:join2/4:109" server=<30887.545.0> msg=other_servers pid=<30887.545.0> node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local
when=2023-10-17T19:10:31.084280+00:00 level=error what=long_task_failed reason={{nodedown,'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'},{gen_server,call,[<30887.545.0>,other_servers,infinity]}} pid=<0.567.0> at=cets_long:run_tracked/2:63 stacktrace="gen_server:call/3:401 cets_long:run_tracked/2:54 cets_join:get_pids/1:192 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:check_fully_connected/2:264 cets_join:check_pids/4:199 cets_join:join2/4:109" local_pid=<0.545.0> remote_pid=<30886.545.0> remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local table=cets_cluster_id
when=2023-10-17T19:10:31.086471+00:00 level=error what=long_task_failed reason={{nodedown,'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'},{gen_server,call,[<30887.545.0>,other_servers,infinity]}} pid=<0.561.0> at=cets_long:run_tracked/2:63 stacktrace="gen_server:call/3:401 cets_long:run_tracked/2:54 cets_join:get_pids/1:192 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:'-check_fully_connected/2-lc$^0/1-0-'/1:264 cets_join:check_fully_connected/2:264 cets_join:check_pids/4:199 cets_join:join2/4:109" long_task_name=join local_pid=<0.545.0> remote_pid=<30886.545.0> remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local table=cets_cluster_id
```

Once inside `cets` call and 2 times inside the `cets_join` module.

Changes:
- This PR removes 2 extra logs.
- Only the most nested call would be logged. In our case - we log from `cets` module. `cets_join` would remain silent.
- We add `task_failed` wrapping when we re-throw the error, to avoid it being reported by the nested long (call from `cets_long` module) call.
- This PR only removes log duplication, in the real life you would still see a lot of messages: because of retry logic and because a message could be potentially logged for each unique table name. At least the amount of logged messages is less now.
- Updated the version of the debug log handler dependency. Because OTP Logger has real hard time when add_handler/remove_handler are called from the different processes (there are race condition bugs there, we would need to create a bug report to the OTP. For now, we would have to use `global:transaction` when adding log handlers in our tests).
