### PR TITLE
Fix cets_status improper missing/unknown tables

### DIFF
--- a/src/cets_status.erl
+++ b/src/cets_status.erl
@@ -140,7 +140,7 @@ get_node_to_tab_nodes_map(AvailNodes, Disco) ->
 %% All joined nodes replicate data between each other.
 -spec joined_nodes(node(), tab_nodes_map(), node_to_tab_nodes_map()) -> [node()].
 joined_nodes(ThisNode, Expected, OtherTabNodes) ->
-    ExpectedTables = maps:keys(Expected),
+    ExpectedTables = maps_keys_sorted(Expected),
     OtherJoined = maps:fold(
         fun(Node, TabNodes, Acc) ->
             case maps:with(ExpectedTables, TabNodes) =:= Expected of
@@ -172,7 +172,7 @@ unknown_tables(OtherTabNodes, Tables, AllTables) ->
 missing_tables(OtherTabNodes, LocalTables) ->
     Zip = maps:fold(
         fun(Node, TabNodes, Acc) ->
-            RemoteTables = maps:keys(TabNodes),
+            RemoteTables = maps_keys_sorted(TabNodes),
             MissingTables = ordsets:subtract(LocalTables, RemoteTables),
             case MissingTables of
                 [] -> Acc;
@@ -213,7 +213,7 @@ conflict_tables(Expected, OtherTabNodes) ->
 -spec all_tables(tab_nodes_map(), node_to_tab_nodes_map()) -> [table_name()].
 all_tables(Expected, OtherTabNodes) ->
     TableNodesVariants = [Expected | maps:values(OtherTabNodes)],
-    TableVariants = lists:map(fun maps:keys/1, TableNodesVariants),
+    TableVariants = lists:map(fun maps_keys_sorted/1, TableNodesVariants),
     ordsets:union(TableVariants).
 
 %% Returns nodes for each table hosted on node()
@@ -243,3 +243,6 @@ discovery_works(#{last_get_nodes_result := {ok, _}}) ->
     true;
 discovery_works(_) ->
     false.
+
+maps_keys_sorted(Map) ->
+    lists:sort(maps:keys(Map)).

--- a/test/cets_SUITE_data/status_data.txt
+++ b/test/cets_SUITE_data/status_data.txt
@@ -1,0 +1,52 @@
+#{
+    system_info =>
+        #{
+            nodes =>
+                [
+                    'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+                    'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+                ],
+            tables => [cets_bosh, cets_external_component],
+            unavailable_nodes => []
+        },
+    available_nodes =>
+        [
+            'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+            'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+        ],
+    local_table_to_other_nodes_map =>
+        #{
+            cets_external_component =>
+                [
+                    'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+                    'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+                ],
+            cets_bosh =>
+                [
+                    'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+                    'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+                ]
+        },
+    node_to_tab_nodes_map =>
+        #{
+            'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local' =>
+                #{
+                    cets_external_component =>
+                        [
+                            'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+                            'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+                        ],
+                    cets_bosh =>
+                        [
+                            'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+                            'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+                        ]
+                }
+        },
+    online_nodes =>
+        [
+            'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
+            'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local'
+        ],
+    this_node => 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local'
+}.


### PR DESCRIPTION
This PR addresses MIM-2092.

systemInfo looks like that when testing in k8s with Helm:

```json
kubectl exec -it mongooseim-0 -- mongooseimctl cets systemInfo
{
  "data" : {
    "cets" : {
      "systemInfo" : {
        "unavailableNodes" : [

        ],
        "remoteUnknownTables" : [
          "cets_s2s_secret",
          "cets_s2s_session",
          "cets_s2s_secret",
          "cets_s2s_session",
          "cets_s2s_secret",
          "cets_s2s_session",
          "cets_s2s_secret",
          "cets_s2s_session",
          "cets_s2s_secret",
          "cets_s2s_session",
          "cets_s2s_secret",
          "cets_bosh",
          "cets_session",
          "cets_bosh",
          ...],
                  "remoteNodesWithUnknownTables" : [
          "mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-7.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-6.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-8.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-5.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-4.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-9.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local"
        ],
        "remoteNodesWithMissingTables" : [
          "mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-7.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-6.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-8.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-5.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-4.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-9.mongooseim.default.svc.cluster.local",
          "mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local"
        ],
        "remoteMissingTables" : [
          "cets_bosh",
          "cets_cluster_id",
          "cets_s2s_secret"
        ],
        ...
```

Why? Because `maps:keys/1` returns sorted keys only in tests (because atoms used in modules are sorted at the compilation step, so it is hard to find this bug in the synthetic environment. Test would also "pass" if we just try to parse `status_data.txt` and pass it into `cets_status:format_data/1`, without first tweaking the atom table like in `cets_SUITE:test_data_for_duplicate_missing_table_in_status/1` function).
Once you start registering atoms dynamically, `maps:keys/1` returns keys in the order atoms were registered in the atom table.

This PR ensures that keys are sorted before we do following calculations (like determining which tables are missing).

This PR also splits `cets_status` into `gather_data` and `format_data`, so we can more easily debug such issues.