### PR TITLE
Rewrite ping

### DIFF
--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -473,6 +473,7 @@ has_join_result_for(Node, Table, #{results := Results}) ->
 handle_system_info(State) ->
     State#{verify_ready => verify_ready(State)}.
 
+-spec handle_nodedown(node(), state()) -> state().
 handle_nodedown(Node, State) ->
     State2 = remember_nodedown_timestamp(Node, State),
     {NodeUpTime, State3} = remove_nodeup_timestamp(Node, State2),
@@ -487,6 +488,7 @@ handle_nodedown(Node, State) ->
     ),
     State3.
 
+-spec handle_nodeup(node(), state()) -> state().
 handle_nodeup(Node, State) ->
     send_start_time_to(Node, State),
     State2 = remember_nodeup_timestamp(Node, State),
@@ -503,20 +505,23 @@ handle_nodeup(Node, State) ->
     ),
     State2.
 
+-spec remember_nodeup_timestamp(node(), state()) -> state().
 remember_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
     Time = erlang:system_time(millisecond),
     Map2 = Map#{Node => Time},
     State#{nodeup_timestamps := Map2}.
 
+-spec remember_nodedown_timestamp(node(), state()) -> state().
 remember_nodedown_timestamp(Node, State = #{nodedown_timestamps := Map}) ->
     Time = erlang:system_time(millisecond),
     Map2 = Map#{Node => Time},
     State#{nodedown_timestamps := Map2}.
 
+-spec remove_nodeup_timestamp(node(), state()) -> {integer(), state()}.
 remove_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
     StartTime = maps:get(Node, Map, undefined),
     NodeUpTime = calculate_uptime(StartTime),
-    Map2 = maps:remove(Node, State),
+    Map2 = maps:remove(Node, Map),
     {NodeUpTime, State#{nodeup_timestamps := Map2}}.
 
 calculate_uptime(undefined) ->

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -92,7 +92,8 @@
     timer_ref := reference() | undefined,
     pending_wait_for_ready := [gen_server:from()],
     nodeup_timestamps := #{node() => milliseconds()},
-    nodedown_timestamps := #{node() => milliseconds()}
+    nodedown_timestamps := #{node() => milliseconds()},
+    start_time := milliseconds()
 }.
 -type milliseconds() :: integer().
 
@@ -154,6 +155,7 @@ wait_for_ready(Server, Timeout) ->
 
 -spec init(term()) -> {ok, state()}.
 init(Opts) ->
+    StartTime = erlang:system_time(millisecond),
     %% Sends nodeup / nodedown
     ok = net_kernel:monitor_nodes(true),
     Mod = maps:get(backend_module, Opts, cets_discovery_file),
@@ -179,7 +181,8 @@ init(Opts) ->
         timer_ref => undefined,
         pending_wait_for_ready => [],
         nodeup_timestamps => #{},
-        nodedown_timestamps => #{}
+        nodedown_timestamps => #{},
+        start_time => StartTime
     },
     %% Set initial timestamps because we would not receive nodeup events for
     %% already connected nodes
@@ -228,7 +231,12 @@ handle_info({nodeup, Node}, State) ->
     {NodeDownTime, State2} = handle_nodeup(Node, State),
     ?LOG_WARNING(
         set_defined(downtime_millisecond_duration, NodeDownTime, #{
-            what => nodeup, remote_node => Node, alive_nodes => length(nodes()) + 1
+            what => nodeup,
+            remote_node => Node,
+            alive_nodes => length(nodes()) + 1,
+            %% We report that time so we could work on minimizing that time.
+            %% It says how long it took to discover nodes after startup.
+            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
         })
     ),
     State3 = remove_node_from_unavailable_list(Node, State2),
@@ -237,7 +245,10 @@ handle_info({nodedown, Node}, State) ->
     {NodeUpTime, State2} = handle_nodedown(Node, State),
     ?LOG_WARNING(
         set_defined(connected_millisecond_duration, NodeUpTime, #{
-            what => nodedown, remote_node => Node, alive_nodes => length(nodes()) + 1
+            what => nodedown,
+            remote_node => Node,
+            alive_nodes => length(nodes()) + 1,
+            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
         })
     ),
     %% Do another check to update unavailable_nodes list
@@ -503,19 +514,23 @@ remove_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
 calculate_uptime(undefined) ->
     undefined;
 calculate_uptime(StartTime) ->
-    Time = erlang:system_time(millisecond),
-    Time - StartTime.
+    time_since(StartTime).
 
 get_downtime(Node, #{nodedown_timestamps := Map}) ->
     case maps:get(Node, Map, undefined) of
         undefined ->
             undefined;
         WentDown ->
-            Time = erlang:system_time(millisecond),
-            Time - WentDown
+            time_since(WentDown)
     end.
 
 set_defined(_Key, undefined, Map) ->
     Map;
 set_defined(Key, Value, Map) ->
     Map#{Key => Value}.
+
+time_since_startup_in_milliseconds(#{start_time := StartTime}) ->
+    time_since(StartTime).
+
+time_since(StartTime) ->
+    erlang:system_time(millisecond) - StartTime.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -93,6 +93,7 @@
     pending_wait_for_ready := [gen_server:from()],
     nodeup_timestamps := #{node() => milliseconds()},
     nodedown_timestamps := #{node() => milliseconds()},
+    node_start_timestamps := #{node() => milliseconds()},
     start_time := milliseconds()
 }.
 -type milliseconds() :: integer().
@@ -181,6 +182,7 @@ init(Opts) ->
         timer_ref => undefined,
         pending_wait_for_ready => [],
         nodeup_timestamps => #{},
+        node_start_timestamps => #{},
         nodedown_timestamps => #{},
         start_time => StartTime
     },
@@ -251,9 +253,12 @@ handle_info({nodedown, Node}, State) ->
             time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
         })
     ),
+    send_start_time_to(Node, State),
     %% Do another check to update unavailable_nodes list
     self() ! check,
     {noreply, State2};
+handle_info({start_time, Node, StartTime}, State) ->
+    {noreply, handle_receive_start_time(Node, StartTime, State)};
 handle_info({joining_finished, Results}, State) ->
     {noreply, handle_joining_finished(Results, State)};
 handle_info({ping_result, Node, Result}, State) ->
@@ -534,3 +539,28 @@ time_since_startup_in_milliseconds(#{start_time := StartTime}) ->
 
 time_since(StartTime) ->
     erlang:system_time(millisecond) - StartTime.
+
+send_start_time_to(Node, #{start_time := StartTime}) ->
+    case erlang:process_info(self(), registered_name) of
+        {registered_name, Name} ->
+            erlang:send({Name, Node}, {start_time, node(), StartTime});
+        _ ->
+            ok
+    end.
+
+handle_receive_start_time(Node, StartTime, State = #{node_start_timestamps := Map}) ->
+    case maps:get(Node, Map, undefined) of
+        undefined ->
+            ok;
+        StartTime ->
+            ?LOG_WARNING(#{
+                what => node_reconnects,
+                remote_node => Node,
+                start_time => StartTime,
+                text => <<"Netsplit recovery. The remote node has been connected to us before.">>
+            });
+        _ ->
+            %% Restarted node reconnected, this is fine during the rolling updates
+            ok
+    end,
+    State#{node_start_timestamps := maps:put(Node, StartTime, Map)}.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -228,7 +228,7 @@ handle_info({nodeup, Node}, State) ->
     {NodeDownTime, State2} = handle_nodeup(Node, State),
     ?LOG_WARNING(
         set_defined(downtime_millisecond_duration, NodeDownTime, #{
-            what => nodeup, remote_node => Node
+            what => nodeup, remote_node => Node, alive_nodes => length(nodes()) + 1
         })
     ),
     State3 = remove_node_from_unavailable_list(Node, State2),
@@ -237,7 +237,7 @@ handle_info({nodedown, Node}, State) ->
     {NodeUpTime, State2} = handle_nodedown(Node, State),
     ?LOG_WARNING(
         set_defined(connected_millisecond_duration, NodeUpTime, #{
-            what => nodedown, remote_node => Node
+            what => nodedown, remote_node => Node, alive_nodes => length(nodes()) + 1
         })
     ),
     %% Do another check to update unavailable_nodes list

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -230,6 +230,11 @@ handle_info(check, State) ->
 handle_info({handle_check_result, Result, BackendState}, State) ->
     {noreply, handle_get_nodes_result(Result, BackendState, State)};
 handle_info({nodeup, Node}, State) ->
+    %% nodeup triggers get_nodes call.
+    %% We are interested in up-to-date data
+    %% (in MongooseIM we want to know IPs of other nodes as soon as possible
+    %%  after some node connects to us)
+    self() ! check,
     State2 = handle_nodeup(Node, State),
     State3 = remove_node_from_unavailable_list(Node, State2),
     {noreply, try_joining(State3)};

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -482,7 +482,6 @@ handle_system_info(State) ->
 handle_nodedown(Node, State) ->
     State2 = remember_nodedown_timestamp(Node, State),
     {NodeUpTime, State3} = remove_nodeup_timestamp(Node, State2),
-    %% Not inside of the macro to make code coverage happy
     ?LOG_WARNING(
         set_defined(connected_millisecond_duration, NodeUpTime, #{
             what => nodedown,

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -226,16 +226,20 @@ handle_info({handle_check_result, Result, BackendState}, State) ->
     {noreply, handle_get_nodes_result(Result, BackendState, State)};
 handle_info({nodeup, Node}, State) ->
     {NodeDownTime, State2} = handle_nodeup(Node, State),
-    ?LOG_WARNING(#{
-        what => nodeup, remote_node => Node, downtime_millisecond_duration => NodeDownTime
-    }),
+    ?LOG_WARNING(
+        set_defined(downtime_millisecond_duration, NodeDownTime, #{
+            what => nodeup, remote_node => Node
+        })
+    ),
     State3 = remove_node_from_unavailable_list(Node, State2),
     {noreply, try_joining(State3)};
 handle_info({nodedown, Node}, State) ->
     {NodeUpTime, State2} = handle_nodedown(Node, State),
-    ?LOG_WARNING(#{
-        what => nodedown, remote_node => Node, connected_millisecond_duration => NodeUpTime
-    }),
+    ?LOG_WARNING(
+        set_defined(connected_millisecond_duration, NodeUpTime, #{
+            what => nodedown, remote_node => Node
+        })
+    ),
     %% Do another check to update unavailable_nodes list
     self() ! check,
     {noreply, State2};
@@ -510,3 +514,8 @@ get_downtime(Node, #{nodedown_timestamps := Map}) ->
             Time = erlang:system_time(millisecond),
             Time - WentDown
     end.
+
+set_defined(_Key, undefined, Map) ->
+    Map;
+set_defined(Key, Value, Map) ->
+    Map#{Key => Value}.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -476,30 +476,29 @@ handle_system_info(State) ->
 handle_nodedown(Node, State) ->
     State2 = remember_nodedown_timestamp(Node, State),
     {NodeUpTime, State3} = remove_nodeup_timestamp(Node, State2),
-    ?LOG_WARNING(
-        set_defined(connected_millisecond_duration, NodeUpTime, #{
-            what => nodedown,
-            remote_node => Node,
-            alive_nodes => length(nodes()) + 1,
-            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
-        })
-    ),
+    %% Not inside of the macro to make code coverage happy
+    Log = set_defined(connected_millisecond_duration, NodeUpTime, #{
+        what => nodedown,
+        remote_node => Node,
+        alive_nodes => length(nodes()) + 1,
+        time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
+    }),
+    ?LOG_WARNING(Log),
     State3.
 
 handle_nodeup(Node, State) ->
     send_start_time_to(Node, State),
     State2 = remember_nodeup_timestamp(Node, State),
     NodeDownTime = get_downtime(Node, State2),
-    ?LOG_WARNING(
-        set_defined(downtime_millisecond_duration, NodeDownTime, #{
-            what => nodeup,
-            remote_node => Node,
-            alive_nodes => length(nodes()) + 1,
-            %% We report that time so we could work on minimizing that time.
-            %% It says how long it took to discover nodes after startup.
-            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
-        })
-    ),
+    Log = set_defined(downtime_millisecond_duration, NodeDownTime, #{
+        what => nodeup,
+        remote_node => Node,
+        alive_nodes => length(nodes()) + 1,
+        %% We report that time so we could work on minimizing that time.
+        %% It says how long it took to discover nodes after startup.
+        time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
+    }),
+    ?LOG_WARNING(Log),
     State2.
 
 remember_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -491,21 +491,21 @@ remember_nodedown_timestamp(Node, State = #{nodedown_timestamps := Map}) ->
     State#{nodedown_timestamps := Map2}.
 
 remove_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
-    StartTime = maps:get(Node, Map, unknown),
+    StartTime = maps:get(Node, Map, undefined),
     NodeUpTime = calculate_uptime(StartTime),
     Map2 = maps:remove(Node, State),
     {NodeUpTime, State#{nodeup_timestamps := Map2}}.
 
-calculate_uptime(unknown) ->
-    unknown;
+calculate_uptime(undefined) ->
+    undefined;
 calculate_uptime(StartTime) ->
     Time = erlang:system_time(millisecond),
     Time - StartTime.
 
 get_downtime(Node, #{nodedown_timestamps := Map}) ->
-    case maps:get(Node, Map, unknown) of
-        unknown ->
-            unknown;
+    case maps:get(Node, Map, undefined) of
+        undefined ->
+            undefined;
         WentDown ->
             Time = erlang:system_time(millisecond),
             Time - WentDown

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -90,8 +90,10 @@
     join_status := not_running | running,
     should_retry_join := boolean(),
     timer_ref := reference() | undefined,
-    pending_wait_for_ready := [gen_server:from()]
+    pending_wait_for_ready := [gen_server:from()],
+    nodeup_timestamps := #{node() => milliseconds()}
 }.
+-type milliseconds() :: integer().
 
 %% Backend could define its own options
 -type opts() :: #{name := atom(), _ := _}.
@@ -159,7 +161,7 @@ init(Opts) ->
     BackendState = Mod:init(Opts),
     %% Changes phase from initial to regular (affects the check interval)
     erlang:send_after(timer:minutes(5), self(), enter_regular_phase),
-    {ok, #{
+    State = #{
         phase => initial,
         results => [],
         nodes => [],
@@ -174,8 +176,13 @@ init(Opts) ->
         join_status => not_running,
         should_retry_join => false,
         timer_ref => undefined,
-        pending_wait_for_ready => []
-    }}.
+        pending_wait_for_ready => [],
+        nodeup_timestamps => #{}
+    },
+    %% Set initial timestamps because we would not receive nodeup events for
+    %% already connected nodes
+    State2 = lists:foldl(fun remember_nodeup_timestamp/2, State, nodes()),
+    {ok, State2}.
 
 -spec handle_call(term(), from(), state()) -> {reply, term(), state()} | {noreply, state()}.
 handle_call(get_tables, _From, State = #{tables := Tables}) ->
@@ -216,12 +223,15 @@ handle_info(check, State) ->
 handle_info({handle_check_result, Result, BackendState}, State) ->
     {noreply, handle_get_nodes_result(Result, BackendState, State)};
 handle_info({nodeup, Node}, State) ->
+    ?LOG_WARNING(#{what => nodeup, remote_node => Node}),
     State2 = remove_node_from_unavailable_list(Node, State),
-    {noreply, try_joining(State2)};
-handle_info({nodedown, _Node}, State) ->
+    {noreply, remember_nodeup_timestamp(Node, try_joining(State2))};
+handle_info({nodedown, Node}, State) ->
+    {NodeUpTime, State2} = remove_nodeup_timestamp(Node, State),
+    ?LOG_WARNING(#{what => nodedown, remote_node => Node, connected_for_milliseconds => NodeUpTime}),
     %% Do another check to update unavailable_nodes list
     self() ! check,
-    {noreply, State};
+    {noreply, State2};
 handle_info({joining_finished, Results}, State) ->
     {noreply, handle_joining_finished(Results, State)};
 handle_info({ping_result, Node, Result}, State) ->
@@ -454,3 +464,20 @@ has_join_result_for(Node, Table, #{results := Results}) ->
 -spec handle_system_info(state()) -> system_info().
 handle_system_info(State) ->
     State#{verify_ready => verify_ready(State)}.
+
+remember_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
+    Time = erlang:system_time(millisecond),
+    Map2 = Map#{Node => Time},
+    State#{nodeup_timestamps := Map2}.
+
+remove_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->
+    StartTime = maps:get(Node, Map, unknown),
+    NodeUpTime = calculate_uptime(StartTime),
+    Map2 = maps:remove(Node, State),
+    {NodeUpTime, Map2}.
+
+calculate_uptime(unknown) ->
+    unknown;
+calculate_uptime(StartTime) ->
+    Time = erlang:system_time(millisecond),
+    Time - StartTime.

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -477,28 +477,30 @@ handle_nodedown(Node, State) ->
     State2 = remember_nodedown_timestamp(Node, State),
     {NodeUpTime, State3} = remove_nodeup_timestamp(Node, State2),
     %% Not inside of the macro to make code coverage happy
-    Log = set_defined(connected_millisecond_duration, NodeUpTime, #{
-        what => nodedown,
-        remote_node => Node,
-        alive_nodes => length(nodes()) + 1,
-        time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
-    }),
-    ?LOG_WARNING(Log),
+    ?LOG_WARNING(
+        set_defined(connected_millisecond_duration, NodeUpTime, #{
+            what => nodedown,
+            remote_node => Node,
+            alive_nodes => length(nodes()) + 1,
+            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
+        })
+    ),
     State3.
 
 handle_nodeup(Node, State) ->
     send_start_time_to(Node, State),
     State2 = remember_nodeup_timestamp(Node, State),
     NodeDownTime = get_downtime(Node, State2),
-    Log = set_defined(downtime_millisecond_duration, NodeDownTime, #{
-        what => nodeup,
-        remote_node => Node,
-        alive_nodes => length(nodes()) + 1,
-        %% We report that time so we could work on minimizing that time.
-        %% It says how long it took to discover nodes after startup.
-        time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
-    }),
-    ?LOG_WARNING(Log),
+    ?LOG_WARNING(
+        set_defined(downtime_millisecond_duration, NodeDownTime, #{
+            what => nodeup,
+            remote_node => Node,
+            alive_nodes => length(nodes()) + 1,
+            %% We report that time so we could work on minimizing that time.
+            %% It says how long it took to discover nodes after startup.
+            time_since_startup_in_milliseconds => time_since_startup_in_milliseconds(State)
+        })
+    ),
     State2.
 
 remember_nodeup_timestamp(Node, State = #{nodeup_timestamps := Map}) ->

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -315,7 +315,7 @@ ping_not_connected_nodes(Nodes) ->
     Self = self(),
     NotConNodes = Nodes -- [node() | nodes()],
     [
-        spawn(fun() -> Self ! {ping_result, Node, net_adm:ping(Node)} end)
+        spawn(fun() -> Self ! {ping_result, Node, cets_ping:ping(Node)} end)
      || Node <- lists:sort(NotConNodes)
     ],
     ok.

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -195,9 +195,9 @@ get_pids(Pid) ->
 check_pids(Info, LocPids, RemPids, JoinOpts) ->
     check_do_not_overlap(Info, LocPids, RemPids),
     checkpoint(before_check_fully_connected, JoinOpts),
+    check_could_reach_each_other(Info, LocPids, RemPids),
     check_fully_connected(Info, LocPids),
-    check_fully_connected(Info, RemPids),
-    check_could_reach_each_other(Info, LocPids, RemPids).
+    check_fully_connected(Info, RemPids).
 
 -spec check_could_reach_each_other(cets_long:log_info(), cets:servers(), cets:servers()) -> ok.
 check_could_reach_each_other(Info, LocPids, RemPids) ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -207,16 +207,7 @@ check_could_reach_each_other(Info, LocPids, RemPids) ->
         {min(LocNode, RemNode), max(LocNode, RemNode)}
      || LocNode <- LocNodes, RemNode <- RemNodes, LocNode =/= RemNode
     ]),
-    Results =
-        [
-            {Node1, Node2,
-                cets_long:run_tracked(
-                    #{task => ping_node, node1 => Node1, node2 => Node2}, fun() ->
-                        rpc:call(Node1, net_adm, ping, [Node2], 10000)
-                    end
-                )}
-         || {Node1, Node2} <- Pairs
-        ],
+    Results = cets_ping:ping_pairs(Pairs),
     NotConnected = [X || {_Node1, _Node2, Res} = X <- Results, Res =/= pong],
     case NotConnected of
         [] ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -84,10 +84,12 @@ join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts) ->
     %% Just lock all nodes, no magic here :)
     Nodes = [node() | nodes()],
     Retries = 1,
+    %% global could abort the transaction when one of the nodes goes down.
+    %% It could usually abort it during startup or update.
     case global:trans(LockRequest, F, Nodes, Retries) of
         aborted ->
             checkpoint(before_retry, JoinOpts),
-            ?LOG_ERROR(Info#{what => join_retry, reason => lock_aborted}),
+            ?LOG_INFO(Info#{what => join_retry, reason => lock_aborted}),
             join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts);
         Result ->
             Result

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -91,8 +91,8 @@ run_monitor(Info, Ref, Parent, Start) ->
 
 monitor_loop(Mon, Info, Parent, Start, Interval) ->
     receive
-        {'DOWN', _MonRef, process, _Pid, stop} ->
-            %% Special case, the long task is stopped using exit(Pid, stop)
+        {'DOWN', _MonRef, process, _Pid, shutdown} ->
+            %% Special case, the long task is stopped using exit(Pid, shutdown)
             ok;
         {'DOWN', MonRef, process, _Pid, Reason} when Mon =:= MonRef ->
             ?LOG_ERROR(Info#{

--- a/src/cets_long.erl
+++ b/src/cets_long.erl
@@ -91,6 +91,9 @@ run_monitor(Info, Ref, Parent, Start) ->
 
 monitor_loop(Mon, Info, Parent, Start, Interval) ->
     receive
+        {'DOWN', _MonRef, process, _Pid, stop} ->
+            %% Special case, the long task is stopped using exit(Pid, stop)
+            ok;
         {'DOWN', MonRef, process, _Pid, Reason} when Mon =:= MonRef ->
             ?LOG_ERROR(Info#{
                 what => task_failed,

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -15,8 +15,11 @@ ping(Node) when is_atom(Node) ->
             pong;
         false ->
             case dist_util:split_node(Node) of
-                {node, _Name, Host} ->
-                    case {inet:getaddr(Host, inet6), inet:getaddr(Host, inet)} of
+                {node, Name, Host} ->
+                    Epmd = net_kernel:epmd_module(),
+                    V4 = Epmd:address_please(Name, Host, inet),
+                    V6 = Epmd:address_please(Name, Host, inet6),
+                    case {V4, V6} of
                         {{error, _}, {error, _}} ->
                             pang;
                         _ ->

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -40,12 +40,11 @@ net_family(_) ->
     inet.
 
 connect_ping(Node) ->
-    %% We could use net_adm:ping/1 but it does:
-    %% - disconnect node on pang - we don't want that
-    %%   (because it could disconnect already connected node because of race conditions)
-    %% - it calls net_kernel's gen_server of the remote server,
-    %%   but it could be busy doing something,
-    %%   which means slower response time.
+    %% We could use net_adm:ping/1 but it:
+    %% - disconnects node on pang - we don't want that
+    %%   (because it could disconnect an already connected node because of race conditions)
+    %% - calls net_kernel's gen_server of the remote server,
+    %%   but it could be busy doing something, which means slower response time.
     case net_kernel:connect_node(Node) of
         true ->
             pong;
@@ -69,7 +68,7 @@ ping_pairs_stop_on_pang([{Node1, Node2} | Pairs]) ->
         Other ->
             %% We do not need to ping the rest of nodes -
             %% one node returning pang is enough to cancel join.
-            %% We could exit earlier and safe some time
+            %% We could exit earlier and save some time
             %% (connect_node to the dead node could be time consuming)
             [{Node1, Node2, Other} | fail_pairs(Pairs, skipped)]
     end;

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -19,17 +19,13 @@ ping(Node) when is_atom(Node) ->
         true ->
             pong;
         false ->
-            case dist_util:split_node(Node) of
-                {node, Name, Host} ->
-                    Epmd = net_kernel:epmd_module(),
-                    case Epmd:address_please(Name, Host, net_family()) of
-                        {error, _} ->
-                            pang;
-                        _ ->
-                            connect_ping(Node)
-                    end;
+            {node, Name, Host} = dist_util:split_node(Node),
+            Epmd = net_kernel:epmd_module(),
+            case Epmd:address_please(Name, Host, net_family()) of
+                {error, _} ->
+                    pang;
                 _ ->
-                    pang
+                    connect_ping(Node)
             end
     end.
 

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -1,5 +1,10 @@
 -module(cets_ping).
 -export([ping/1, ping_pairs/1]).
+
+-ifdef(TEST).
+-export([net_family/1]).
+-endif.
+
 ping(Node) when is_atom(Node) ->
     %% It is important to understand, that initial setup for dist connections
     %% is done by the single net_kernel process.

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -34,14 +34,8 @@ ping(Node) when is_atom(Node) ->
 net_family() ->
     net_family(init:get_argument(proto_dist)).
 
-net_family({ok, [[ProtoDist]]}) ->
-    %% Check that the string contains "6". i.e. inet6, inet6_tls.
-    case lists:member($6, ProtoDist) of
-        true ->
-            inet6;
-        false ->
-            inet
-    end;
+net_family({ok, [["inet6" ++ _]]}) ->
+    inet6;
 net_family(_) ->
     inet.
 

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -1,0 +1,44 @@
+-module(cets_ping).
+-export([ping/1]).
+ping(Node) when is_atom(Node) ->
+    %% It is important to understand, that initial setup for dist connections
+    %% is done by the single net_kernel process.
+    %% It calls net_kernel:setup, which calls inet_tcp_dist, which calls
+    %% erl_epmd:address_please/3, which does a DNS request.
+    %% If DNS is slow - net_kernel process would become busy.
+    %% But if we have a lot of offline nodes in the CETS discovery table,
+    %% we would try to call net_kernel for each node (even if we probably would receive
+    %% {error, nxdomain} from erl_epmd:address_please/3).
+    %% So, we first do nslookup here and only after that we try to connect.
+    case lists:member(Node, nodes()) of
+        true ->
+            pong;
+        false ->
+            case dist_util:split_node(Node) of
+                {node, _Name, Host} ->
+                    case {inet:getaddr(Host, inet6), inet:getaddr(Host, inet)} of
+                        {{error, _}, {error, _}} ->
+                            pang;
+                        _ ->
+                            ping_without_disconnect(Node)
+                    end;
+                _ ->
+                    pang
+            end
+    end.
+
+%% net_adm:ping/1 but without disconnect_node
+%% (because disconnect_node could introduce more chaos and it is not atomic)
+ping_without_disconnect(Node) ->
+    Msg = {is_auth, node()},
+    Dst = {net_kernel, Node},
+    try gen:call(Dst, '$gen_call', Msg, infinity) of
+        {ok, yes} ->
+            pong;
+        _ ->
+            % erlang:disconnect_node(Node),
+            pang
+    catch
+        _:_ ->
+            pang
+    end.

--- a/src/cets_status.erl
+++ b/src/cets_status.erl
@@ -64,7 +64,7 @@ gather_data(Disco) ->
     ThisNode = node(),
     Info = cets_discovery:system_info(Disco),
     #{tables := Tables} = Info,
-    OnlineNodes = [ThisNode | nodes()],
+    OnlineNodes = lists:sort([ThisNode | nodes()]),
     AvailNodes = available_nodes(Disco, OnlineNodes),
     Expected = get_local_table_to_other_nodes_map(Tables),
     OtherTabNodes = get_node_to_tab_nodes_map(AvailNodes, Disco),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -162,7 +162,7 @@ only_for_logger_cases() ->
         logs_are_printed_when_join_fails_because_servers_overlap,
         join_done_already_while_waiting_for_lock_so_do_nothing,
         atom_error_is_logged_in_tracked,
-        stop_reason_is_not_logged_in_tracked,
+        shutdown_reason_is_not_logged_in_tracked,
         other_reason_is_logged_in_tracked,
         nested_calls_errors_are_logged_once_with_tuple_reason,
         nested_calls_errors_are_logged_once_with_map_reason
@@ -1026,7 +1026,7 @@ atom_error_is_logged_in_tracked(_Config) ->
     ] =
         receive_all_logs_with_log_ref(?FUNCTION_NAME, LogRef).
 
-stop_reason_is_not_logged_in_tracked(_Config) ->
+shutdown_reason_is_not_logged_in_tracked(_Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     Me = self(),
     LogRef = make_ref(),
@@ -1036,11 +1036,11 @@ stop_reason_is_not_logged_in_tracked(_Config) ->
     end,
     Pid = spawn(fun() -> cets_long:run_tracked(#{log_ref => LogRef}, F) end),
     receive_message(ready),
-    exit(Pid, stop),
+    exit(Pid, shutdown),
     wait_for_down(Pid),
     [] = receive_all_logs_with_log_ref(?FUNCTION_NAME, LogRef).
 
-%% Counter example for stop_reason_is_not_logged_in_tracked
+%% Counter example for shutdown_reason_is_not_logged_in_tracked
 other_reason_is_logged_in_tracked(_Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     Me = self(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -174,7 +174,8 @@ seq_cases() ->
         %% Cannot be run in parallel with other tests because checks all logging messages.
         logging_when_failing_join_with_disco,
         cets_ping_all_returns_when_ping_crashes,
-        join_interrupted_when_ping_crashes
+        join_interrupted_when_ping_crashes,
+        disco_logs_nodeup
     ].
 
 cets_seq_no_log_cases() ->
@@ -2226,6 +2227,33 @@ node_down_history_is_updated_when_netsplit_happens(Config) ->
     after
         reconnect_node(Node5, Peer5),
         cets:stop(Pid5)
+    end.
+
+disco_logs_nodeup(Config) ->
+    logger_debug_h:start(#{id => ?FUNCTION_NAME}),
+    Node1 = node(),
+    #{ct2 := Peer2} = proplists:get_value(peers, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    rpc(Peer2, erlang, disconnect_node, [Node1]),
+    Tab = make_name(Config),
+    {ok, _Pid1} = start(Node1, Tab),
+    {ok, _Pid2} = start(Peer2, Tab),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    cets_discovery:add_table(Disco, Tab),
+    receive
+        {log, ?FUNCTION_NAME, #{
+            level := warning,
+            msg := {report, #{what := nodeup}}
+        }} ->
+            ok
+    after 5000 ->
+        ct:fail(timeout)
     end.
 
 format_data_does_not_return_table_duplicates(Config) ->

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2414,10 +2414,11 @@ disco_logs_node_reconnects_after_downtime(Config) ->
             msg :=
                 {report, #{
                     what := node_reconnects,
+                    start_time := StartTime,
                     remote_node := Node2
                 }}
-        }} ->
-            ok
+        }} = M ->
+            ?assert(is_integer(StartTime), M)
     after 5000 ->
         ct:fail(timeout)
     end.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -178,15 +178,15 @@ seq_cases() ->
         disco_logs_nodeup,
         disco_logs_nodedown,
         disco_logs_nodeup_after_downtime,
-        disco_logs_node_reconnects_after_downtime
+        disco_logs_node_reconnects_after_downtime,
+        disco_node_up_timestamp_is_remembered,
+        disco_logs_nodedown_timestamp_is_remembered
     ].
 
 cets_seq_no_log_cases() ->
     [
         join_interrupted_when_ping_crashes,
-        node_down_history_is_updated_when_netsplit_happens,
-        disco_logs_nodeup_no_log,
-        disco_logs_nodedown_no_log
+        node_down_history_is_updated_when_netsplit_happens
     ].
 
 init_per_suite(Config) ->
@@ -2262,8 +2262,7 @@ disco_logs_nodeup(Config) ->
         ct:fail(timeout)
     end.
 
-%% disco_logs_nodeup, but logger is disabled (for code coverage)
-disco_logs_nodeup_no_log(Config) ->
+disco_node_up_timestamp_is_remembered(Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     Node1 = node(),
     #{ct2 := Peer2} = proplists:get_value(peers, Config),
@@ -2320,7 +2319,7 @@ disco_logs_nodedown(Config) ->
         ct:fail(timeout)
     end.
 
-disco_logs_nodedown_no_log(Config) ->
+disco_logs_nodedown_timestamp_is_remembered(Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     Node1 = node(),
     #{ct2 := Peer2} = proplists:get_value(peers, Config),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2087,8 +2087,7 @@ joining_not_fully_connected_node_is_not_allowed(Config) ->
         %% Pid5 and Pid3 could contact each other.
         %% Pid3 could contact Pid1 (they are joined).
         %% But Pid5 cannot contact Pid1.
-        {error,
-            {task_failed, {{nodedown, Node1}, {gen_server, call, [_, other_servers, infinity]}}, _}} =
+        {error, {task_failed, check_could_reach_each_other_failed, _}} =
             rpc(Peer5, cets_join, join, [lock_name(Config), #{}, Pid5, Pid3]),
         %% Still connected
         cets:insert(Pid1, {r1}),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -150,7 +150,8 @@ cases() ->
         send_leader_op_throws_noproc,
         pinfo_returns_value,
         pinfo_returns_undefined,
-        format_data_does_not_return_table_duplicates
+        format_data_does_not_return_table_duplicates,
+        cets_ping_non_existing_node
     ].
 
 only_for_logger_cases() ->
@@ -2507,6 +2508,9 @@ disco_node_start_timestamp_is_updated_after_node_restarts(Config) ->
 format_data_does_not_return_table_duplicates(Config) ->
     Res = cets_status:format_data(test_data_for_duplicate_missing_table_in_status(Config)),
     ?assertMatch(#{remote_unknown_tables := [], remote_nodes_with_missing_tables := []}, Res).
+
+cets_ping_non_existing_node(_Config) ->
+    pang = cets_ping:ping('mongooseim@non_existing_host').
 
 %% Helper functions
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -187,7 +187,9 @@ seq_cases() ->
         disco_node_up_timestamp_is_remembered,
         disco_node_down_timestamp_is_remembered,
         disco_nodeup_timestamp_is_updated_after_node_reconnects,
-        disco_node_start_timestamp_is_updated_after_node_restarts
+        disco_node_start_timestamp_is_updated_after_node_restarts,
+        ping_pairs_returns_pongs,
+        ping_pairs_returns_earlier
     ].
 
 cets_seq_no_log_cases() ->
@@ -2582,6 +2584,19 @@ unexpected_nodedown_is_ignored_by_disco(Config) ->
     %% Check that we are still running
     #{start_time := StartTime} = cets_discovery:system_info(Disco),
     ok.
+
+ping_pairs_returns_pongs(Config) ->
+    #{ct2 := Node2, ct3 := Node3} = proplists:get_value(nodes, Config),
+    Me = node(),
+    [{Me, Node2, pong}, {Node2, Node3, pong}] =
+        cets_ping:ping_pairs([{Me, Node2}, {Node2, Node3}]).
+
+ping_pairs_returns_earlier(Config) ->
+    #{ct2 := Node2, ct3 := Node3} = proplists:get_value(nodes, Config),
+    Me = node(),
+    Bad = 'badnode@localhost',
+    [{Me, Me, pong}, {Me, Node2, pong}, {Me, Bad, pang}, {Me, Node3, skipped}] =
+        cets_ping:ping_pairs([{Me, Me}, {Me, Node2}, {Me, Bad}, {Me, Node3}]).
 
 %% Helper functions
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -180,7 +180,7 @@ seq_cases() ->
         disco_logs_nodeup_after_downtime,
         disco_logs_node_reconnects_after_downtime,
         disco_node_up_timestamp_is_remembered,
-        disco_logs_nodedown_timestamp_is_remembered,
+        disco_node_down_timestamp_is_remembered,
         disco_nodeup_timestamp_is_updated_after_node_reconnects,
         disco_node_start_timestamp_is_updated_after_node_restarts
     ].
@@ -189,6 +189,8 @@ cets_seq_no_log_cases() ->
     [
         join_interrupted_when_ping_crashes,
         node_down_history_is_updated_when_netsplit_happens,
+        disco_node_up_timestamp_is_remembered,
+        disco_node_down_timestamp_is_remembered,
         disco_nodeup_timestamp_is_updated_after_node_reconnects,
         disco_node_start_timestamp_is_updated_after_node_restarts
     ].
@@ -231,7 +233,7 @@ end_per_testcase(_, _Config) ->
 
 %% Modules that use a multiline LOG_ macro
 log_modules() ->
-    [cets, cets_call, cets_long, cets_join].
+    [cets, cets_call, cets_long, cets_join, cets_discovery].
 
 inserted_records_could_be_read_back(Config) ->
     Tab = make_name(Config),
@@ -2322,7 +2324,7 @@ disco_logs_nodedown(Config) ->
         ct:fail(timeout)
     end.
 
-disco_logs_nodedown_timestamp_is_remembered(Config) ->
+disco_node_down_timestamp_is_remembered(Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     Node1 = node(),
     #{ct2 := Peer2} = proplists:get_value(peers, Config),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -151,7 +151,8 @@ cases() ->
         pinfo_returns_value,
         pinfo_returns_undefined,
         format_data_does_not_return_table_duplicates,
-        cets_ping_non_existing_node
+        cets_ping_non_existing_node,
+        cets_ping_net_family
     ].
 
 only_for_logger_cases() ->
@@ -2511,6 +2512,12 @@ format_data_does_not_return_table_duplicates(Config) ->
 
 cets_ping_non_existing_node(_Config) ->
     pang = cets_ping:ping('mongooseim@non_existing_host').
+
+cets_ping_net_family(_Config) ->
+    inet = cets_ping:net_family(error),
+    inet = cets_ping:net_family({ok, [["inet"]]}),
+    inet6 = cets_ping:net_family({ok, [["inet6"]]}),
+    inet6 = cets_ping:net_family({ok, [["inet6_tls"]]}).
 
 %% Helper functions
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -175,7 +175,8 @@ seq_cases() ->
         logging_when_failing_join_with_disco,
         cets_ping_all_returns_when_ping_crashes,
         join_interrupted_when_ping_crashes,
-        disco_logs_nodeup
+        disco_logs_nodeup,
+        disco_logs_nodedown
     ].
 
 cets_seq_no_log_cases() ->
@@ -2250,6 +2251,35 @@ disco_logs_nodeup(Config) ->
         {log, ?FUNCTION_NAME, #{
             level := warning,
             msg := {report, #{what := nodeup}}
+        }} ->
+            ok
+    after 5000 ->
+        ct:fail(timeout)
+    end.
+
+disco_logs_nodedown(Config) ->
+    logger_debug_h:start(#{id => ?FUNCTION_NAME}),
+    Node1 = node(),
+    #{ct2 := Peer2} = proplists:get_value(peers, Config),
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    rpc(Peer2, erlang, disconnect_node, [Node1]),
+    Tab = make_name(Config),
+    {ok, _Pid1} = start(Node1, Tab),
+    {ok, _Pid2} = start(Peer2, Tab),
+    F = fun(State) ->
+        {{ok, [Node1, Node2]}, State}
+    end,
+    DiscoName = disco_name(Config),
+    Disco = start_disco(Node1, #{
+        name => DiscoName, backend_module => cets_discovery_fun, get_nodes_fn => F
+    }),
+    cets_discovery:add_table(Disco, Tab),
+    ok = cets_discovery:wait_for_ready(Disco, 5000),
+    rpc(Peer2, erlang, disconnect_node, [Node1]),
+    receive
+        {log, ?FUNCTION_NAME, #{
+            level := warning,
+            msg := {report, #{what := nodedown}}
         }} ->
             ok
     after 5000 ->


### PR DESCRIPTION
Changes:
- Introduce cets_ping with better node pinging strategy. It interrupts ping, if pang is received. It does not use net_adm:ping/1 to avoid going though net_kernel and potentially blocking it for a couple of seconds if the remote node is not available (couple of seconds adds up fast, if we have a lot of nodes). The current strategy is try to call EPMD first to check if the remote address is resolvable.
- Improve logging. Report nodeup/nodedown with downtime duration and time since the node start. It is especially useful when tweaking probes and upgrading k8s.
- Added node_down_history field to CETS. It looks like currently unused, but the purpose is to be able to analyse it manually and check after netsplits. It is added, because before we had conflict_nodes/conflict_tables persistently (i.e. after a netsplit, nodes see different lists). Still, I cannot reproduce conflict bug anymore, after tens of runs - so works as expected.
