### PR TITLE
Enable cets_discovery get_nodes queries even with no tables

### DIFF
--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -281,9 +281,6 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 -spec handle_check(state()) -> state().
-handle_check(State = #{tables := []}) ->
-    %% No tables to track, skip
-    State;
 handle_check(State = #{get_nodes_status := running}) ->
     State#{should_retry_get_nodes := true};
 handle_check(State = #{backend_module := Mod, backend_state := BackendState}) ->


### PR DESCRIPTION
Enable cets_discovery get_nodes queries even with no tables.

Discovery is important to join nodes, so enable it even with no added tables to track.
This should simplify logic and testing a bit.