### PR TITLE
Check if we can connect to the remote node before doing connect_node

### DIFF
--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -48,7 +48,7 @@ can_preconnect_from_all_nodes(Node) ->
             %% Node is probably down, skip multicall
             false;
         pong ->
-            Results = erpc:multicall(Nodes, ?MODULE, pre_connect, [Node], infinity),
+            Results = erpc:multicall(Nodes, ?MODULE, pre_connect, [Node], 5000),
             %% We skip nodes which do not have cets_ping module and return an error
             not lists:member({ok, pang}, Results)
     end.

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -134,8 +134,7 @@ fail_pairs(Pairs, Reason) ->
 
 -spec can_connect(inet:ip_address()) -> boolean().
 can_connect(IP) ->
-    Timeout = 1000,
-    case try_open(IP, Timeout) of
+    case gen_tcp:connect(IP, get_epmd_port(), [], 5000) of
         {ok, Socket} ->
             gen_tcp:close(Socket),
             true;
@@ -151,9 +150,3 @@ get_epmd_port() ->
         error ->
             4369
     end.
-
-try_open({_, _, _, _} = IP, Timeout) ->
-    %% That would block
-    gen_tcp:connect(IP, get_epmd_port(), [inet], Timeout);
-try_open({_, _, _, _, _, _, _, _} = IP, Timeout) ->
-    gen_tcp:connect(IP, get_epmd_port(), [inet6], Timeout).

--- a/src/cets_ping.erl
+++ b/src/cets_ping.erl
@@ -30,10 +30,11 @@ can_preconnect_from_all_nodes(PingNode) ->
 
 pre_connect_list([Node | Nodes], PingNode) ->
     case rpc:call(Node, ?MODULE, pre_connect, [PingNode]) of
-        pong ->
-            pre_connect_list(Nodes, PingNode);
+        pang ->
+            false;
         _ ->
-            false
+            %% We skip node in case it does not have CETS nodules
+            pre_connect_list(Nodes, PingNode)
     end;
 pre_connect_list([], _PingNode) ->
     true.

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -193,7 +193,9 @@ seq_cases() ->
         disco_node_start_timestamp_is_updated_after_node_restarts,
         disco_nodeup_triggers_check_and_get_nodes,
         ping_pairs_returns_pongs,
-        ping_pairs_returns_earlier
+        ping_pairs_returns_earlier,
+        pre_connect_fails_on_our_node,
+        pre_connect_fails_on_one_of_the_nodes
     ].
 
 cets_seq_no_log_cases() ->
@@ -2483,6 +2485,30 @@ format_data_does_not_return_table_duplicates(Config) ->
 cets_ping_non_existing_node(_Config) ->
     pang = cets_ping:ping('mongooseim@non_existing_host').
 
+pre_connect_fails_on_our_node(_Config) ->
+    mock_epmd(),
+    %% We would fail to connect to the remote EPMD but we would get an IP
+    pang = cets_ping:ping('mongooseim@resolvabletobadip'),
+    meck:unload().
+
+pre_connect_fails_on_one_of_the_nodes(Config) ->
+    #{ct2 := Node2} = proplists:get_value(nodes, Config),
+    mock_epmd(),
+    %% We would get pong on Node2, but would fail an RPC to our hode
+    pang = rpc(Node2, cets_ping, ping, ['cetsnode1@localhost']),
+    History = meck:history(erl_epmd),
+    %% Check that Node2 called us
+    ?assertMatch(
+        [_],
+        [
+            X
+         || {_, {erl_epmd, address_please, ["cetsnode1", "localhost", inet]},
+                {ok, {192, 168, 100, 134}}} = X <- History
+        ],
+        History
+    ),
+    meck:unload().
+
 cets_ping_net_family(_Config) ->
     inet = cets_ping:net_family(error),
     inet = cets_ping:net_family({ok, [["inet"]]}),
@@ -2927,4 +2953,11 @@ make_signalling_process() ->
         receive
             stop -> ok
         end
+    end).
+
+mock_epmd() ->
+    meck:new(erl_epmd, [passthrough, unstick]),
+    meck:expect(erl_epmd, address_please, fun
+        ("cetsnode1", "localhost", inet) -> {ok, {192, 168, 100, 134}};
+        (Name, Host, Family) -> meck:passthrough([Name, Host, Family])
     end).

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2639,6 +2639,8 @@ rpc(Node, M, F, Args) when is_atom(Node) ->
             Other
     end.
 
+%% Set epmd_port for better coverage
+extra_args(ct2) -> ["-epmd_port", "4369"];
 extra_args(ct5) -> ["-kernel", "prevent_overlapping_partitions", "false"];
 extra_args(_) -> "".
 


### PR DESCRIPTION
There is a situation during upgrades:
- node is about to restart.
- it closes one of connections to the remote node.
- it immediately gets contacted again.
- not all nodes would be able to connect. 
- we see node_reconnects warning and global complaining about overlapped networks.
- So, we got nodedown, nodeup, nodedown very quickly instead of just getting nodedown in this situation.

This PR solves node_reconnects warning by ensuring we only call net_kernel:connect_node if still could connect to the node.
Global overlapped warning could still be here, because it is triggered by first disconnect.

Does it increases work we need to do?
- a bit. Usually the check would return earlier because of `lists:member(Node, nodes())` returning true.
- handling nodedown though is very expensive operation - we need to cleanup ETS tables. so it is good to avoid it even by creating testing connections when trying to connect for the first time.

It also would protect us from trying to connect to the node which is dead, but still in DB.


Initial version of the fix had can_connect in mongoose_epmd. There are things to consider:
- doing the check in mongoose_epmd would block net_kernel. This would block opening debug shell.
- doing this check in cets_ping would only block cets_join (and cets_discovery ping call, but this one is async) - which we are perfectly fine with.
- Only cets_discovery makes brand new connecting attempts. 
- Global does connects because of connect_all - but it is first triggered by cets_discovery.
- This code does not guarantee that the following connect_node would succeed. It just improves the odds. 

This PR fixes `level=warning what=node_reconnects` in logs during upgrade:

```
when=2023-11-30T08:55:51.462816+00:00 level=error what=task_failed reason=noproc pid=<0.18856.0> at=cets_long:monitor_loop/5:98 reported_by=monitor_process caller_pid=<0.18851.0> task=cets_wait_for_get_nodes
when=2023-11-30T08:55:51.520335+00:00 level=warning what=nodeup pid=<0.428.0> at=cets_discovery:handle_nodeup/2:525 downtime_millisecond_duration=172 time_since_startup_in_milliseconds=661646 connected_nodes=7 remote_node=mongooseim@mongooseim-6.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.525983+00:00 level=warning what=nodeup pid=<0.428.0> at=cets_discovery:handle_nodeup/2:525 downtime_millisecond_duration=162 time_since_startup_in_milliseconds=661651 connected_nodes=8 remote_node=mongooseim@mongooseim-7.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.538397+00:00 level=warning what=node_reconnects pid=<0.428.0> at=cets_discovery:handle_receive_start_time/3:593 text="Netsplit recovery. The remote node has been connected to us before." start_time=1701334441099 remote_node=mongooseim@mongooseim-6.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.551818+00:00 level=warning what=node_reconnects pid=<0.428.0> at=cets_discovery:handle_receive_start_time/3:593 text="Netsplit recovery. The remote node has been connected to us before." start_time=1701334390440 remote_node=mongooseim@mongooseim-7.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.568547+00:00 level=warning what=nodeup pid=<0.428.0> at=cets_discovery:handle_nodeup/2:525 downtime_millisecond_duration=197 time_since_startup_in_milliseconds=661694 connected_nodes=9 remote_node=mongooseim@mongooseim-8.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.614467+00:00 level=warning what=cleaner_nodedown pid=<0.425.0> at=mongoose_cleaner:handle_info/2:55 text="mongoose_cleaner received nodenown event" down_node=mongooseim@mongooseim-6.mongooseim.default.svc.cluster.local
when=2023-11-30T08:55:51.619700+00:00 level=warning what=nodeup pid=<0.428.0> at=cets_discovery:handle_nodeup/2:525 downtime_millisecond_duration=271 time_since_startup_in_milliseconds=661745 connected_nodes=10 remote_node=mongooseim@mongooseim-5.mongooseim.default.svc.cluster.local
```

Compare old build:

```
helm install mim-test MongooseIM --set replicaCount=10 --set image.tag=PR-4179 --set persistentDatabase=rdbms --set rdbms.username=mongooseim --set rdbms.database=mongooseim --set volatileDatabase=cets --set image.pullPolicy=Always
...wait for 10 nodes...
helm upgrade mim-test MongooseIM --set replicaCount=10 --set image.tag=PR-4179 --set persistentDatabase=rdbms --set rdbms.username=mongooseim --set rdbms.database=mongooseim --set volatileDatabase=cets --set image.pullPolicy=Always
... check logs for mongooseim-0 during updates...
helm uninstall mim-test
```

With new build:

```
helm install mim-test MongooseIM --set replicaCount=10 --set image.tag=PR-4180 --set persistentDatabase=rdbms --set rdbms.username=mongooseim --set rdbms.database=mongooseim --set volatileDatabase=cets --set image.pullPolicy=Always
helm upgrade mim-test MongooseIM --set replicaCount=10 --set image.tag=PR-4180 --set persistentDatabase=rdbms --set rdbms.username=mongooseim --set rdbms.database=mongooseim --set volatileDatabase=cets --set image.pullPolicy=Always
```

Test docker build for this PR is in https://github.com/esl/MongooseIM/pull/4180