### PR TITLE
Pause on all nodes during join

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -765,6 +765,7 @@ handle_check_server(
     %% Delay reply until this server is unpaused.
     State#{delayed_check_server := [{FromPid, JoinRef} | Delayed]};
 handle_check_server(_FromPid, JoinRef, State = #{pause_monitors := [], join_ref := JoinRef}) ->
+    %% check_server passed - do nothing
     State;
 handle_check_server(FromPid, RemoteJoinRef, State = #{pause_monitors := [], join_ref := JoinRef}) ->
     ?LOG_WARNING(#{

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -506,13 +506,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 -spec handle_send_dump(servers(), join_ref(), pause_monitor(), [tuple()], state()) ->
     {reply, ok, state()}.
-handle_send_dump(
-    NewPids,
-    JoinRef,
-    PauseRef,
-    Dump,
-    State = #{tab := Tab, other_servers := Servers, pause_monitors := PauseMons}
-) ->
+handle_send_dump(NewPids, JoinRef, PauseRef, Dump, State) ->
+    #{tab := Tab, other_servers := Servers, pause_monitors := PauseMons} = State,
     case lists:member(PauseRef, PauseMons) of
         true ->
             ets:insert(Tab, Dump),
@@ -563,11 +558,8 @@ handle_down2(RemotePid, Reason, State = #{other_servers := Servers, ack_pid := A
     end.
 
 update_node_down_history(RemotePid, Reason, State = #{node_down_history := History}) ->
-    State#{
-        node_down_history := [
-            #{node => node(RemotePid), pid => RemotePid, reason => Reason} | History
-        ]
-    }.
+    Item = #{node => node(RemotePid), pid => RemotePid, reason => Reason},
+    State#{node_down_history := [Item | History]}.
 
 %% Merge two lists of pids, create the missing monitors.
 -spec add_servers(Servers, Servers) -> Servers when Servers :: servers().

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -159,8 +159,7 @@
     join_ref := join_ref(),
     opts := start_opts(),
     node_down_history := [node_down_history()],
-    pause_monitors := [pause_monitor()],
-    paused := boolean()
+    pause_monitors := [pause_monitor()]
 }.
 
 -type handle_down_fun() :: fun((#{remote_pid := server_pid(), table := table_name()}) -> ok).
@@ -787,7 +786,6 @@ handle_get_info(
         ack_pid => AckPid,
         join_ref => JoinRef,
         node_down_history => DownHistory,
-        paused => PauseMons =/= [],
         pause_monitors => PauseMons,
         opts => Opts
     }.

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -119,7 +119,7 @@
 -type table_name() :: atom().
 -type pause_monitor() :: reference().
 -type servers() :: ordsets:ordset(server_pid()).
--type node_down_history() :: #{node => node(), pid => pid(), reason => term()}.
+-type node_down_event() :: #{node => node(), pid => pid(), reason => term()}.
 -type state() :: #{
     tab := table_name(),
     keypos := pos_integer(),
@@ -132,7 +132,7 @@
     opts := start_opts(),
     backlog := [backlog_entry()],
     pause_monitors := [pause_monitor()],
-    node_down_history := [node_down_history()]
+    node_down_history := [node_down_event()]
 }.
 
 -type long_msg() ::
@@ -158,7 +158,7 @@
     ack_pid := ack_pid(),
     join_ref := join_ref(),
     opts := start_opts(),
-    node_down_history := [node_down_history()],
+    node_down_history := [node_down_event()],
     pause_monitors := [pause_monitor()]
 }.
 

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -184,6 +184,7 @@
     long_msg/0,
     info/0,
     table_name/0,
+    pause_monitor/0,
     servers/0,
     response_return/0,
     response_timeout/0

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -143,7 +143,7 @@ join2(Info, LocalPid, RemotePid, JoinOpts) ->
 -spec pause_servers(AllPids :: [pid(), ...]) -> Paused :: [{pid(), cets:pause_monitor()}].
 pause_servers(AllPids) ->
     %% We should create a pause helper process on each node in the cluster.
-    %% It is to ensure that node that loosing a connection with cets_join coordinator
+    %% It is to ensure that node that losing a connection with cets_join coordinator
     %% would not unpause one of the processes too soon
     %% (because it could start sending remote ops to nodes which are still in the current joining procedure).
     Paused = [{Pid, cets:pause(Pid)} || Pid <- AllPids],
@@ -160,9 +160,9 @@ pause_on_remote_node(JoinerPid, AllPids) ->
     {Pid, Mon} = spawn_monitor(fun() ->
         JoinerMon = erlang:monitor(process, JoinerPid),
         MyNode = node(),
-        %% Ignore pids on the current nodes
+        %% Ignore pids on the current node
         %% (because we only interested in internode connections here).
-        %% Catching because we can ignore loosing some connections here.
+        %% Catching because we can ignore losing some connections here.
         _Pauses = [catch cets:pause(Pid) || Pid <- AllPids, node(Pid) =/= MyNode],
         Self ! {ready, self()},
         receive

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2862,14 +2862,6 @@ flush_message(M) ->
         ok
     end.
 
-flush_messages() ->
-    receive
-        M ->
-            [M | flush_messages()]
-    after 0 ->
-        []
-    end.
-
 make_name(Config) ->
     make_name(Config, 1).
 

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -162,7 +162,9 @@ cases() ->
         format_data_does_not_return_table_duplicates,
         cets_ping_non_existing_node,
         cets_ping_net_family,
-        unexpected_nodedown_is_ignored_by_disco
+        unexpected_nodedown_is_ignored_by_disco,
+        ignore_send_dump_received_when_unpaused,
+        ignore_send_dump_received_when_paused_with_another_pause_ref
     ].
 
 only_for_logger_cases() ->
@@ -176,8 +178,7 @@ only_for_logger_cases() ->
         other_reason_is_logged_in_tracked,
         nested_calls_errors_are_logged_once_with_tuple_reason,
         nested_calls_errors_are_logged_once_with_map_reason,
-        ignore_send_dump_received_when_unpaused,
-        ignore_send_dump_received_when_paused_with_another_pause_ref
+        send_dump_received_when_unpaused_is_logged
     ].
 
 seq_cases() ->
@@ -1167,6 +1168,19 @@ servers_remove_each_other_each_other_if_join_refs_do_not_match_after_unpause(Con
 
 ignore_send_dump_received_when_paused_with_another_pause_ref(Config) ->
     ignore_send_dump_received_when_unpaused([{extra_pause, true} | Config]).
+
+send_dump_received_when_unpaused_is_logged(Config) ->
+    logger_debug_h:start(#{id => ?FUNCTION_NAME}),
+    ignore_send_dump_received_when_unpaused(Config),
+    receive
+        {log, ?FUNCTION_NAME, #{
+            level := error,
+            msg := {report, #{what := send_dump_received_when_unpaused}}
+        }} ->
+            ok
+    after 5000 ->
+        ct:fail(timeout)
+    end.
 
 ignore_send_dump_received_when_unpaused(Config) ->
     Self = self(),

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -141,6 +141,8 @@ cases() ->
         insert_into_keypos_table,
         table_name_works,
         info_contains_opts,
+        info_contains_pause_monitors,
+        info_contains_other_servers,
         check_could_reach_each_other_fails,
         unknown_down_message_is_ignored,
         unknown_message_is_ignored,
@@ -2102,6 +2104,16 @@ info_contains_opts(Config) ->
     T = make_name(Config),
     {ok, Pid} = start_local(T, #{type => bag}),
     #{opts := #{type := bag}} = cets:info(Pid).
+
+info_contains_pause_monitors(Config) ->
+    T = make_name(Config),
+    {ok, Pid} = start_local(T, #{}),
+    PauseMon = cets:pause(Pid),
+    #{pause_monitors := [PauseMon]} = cets:info(Pid).
+
+info_contains_other_servers(Config) ->
+    #{pid1 := Pid1, pid2 := Pid2} = given_two_joined_tables(Config),
+    #{other_servers := [Pid2]} = cets:info(Pid1).
 
 check_could_reach_each_other_fails(_Config) ->
     ?assertException(


### PR DESCRIPTION
To avoid race conditions we have to pause on all nodes.

The issue:
- if join coordinator node looses connection with one of the nodes during join, that node gets unpaused.
- when unpaused, the node would start sending remote ops and check_server requests.
- there is a chance that other nodes in cluster would receive the messages before send_dump.

I've tried to show the errors in tests.

Solution:
- we could delay the messages by unpausing only when all nodes receive DOWN from the cets_join process.

Adresses MIM-2137