### PR TITLE
Ignore pause_owner_crashed log message if the pause owner exits normally

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -528,12 +528,18 @@ handle_send_dump(NewPids, JoinRef, PauseRef, Dump, State) ->
 handle_down(Mon, Pid, Reason, State = #{pause_monitors := Mons}) ->
     case lists:member(Mon, Mons) of
         true ->
-            ?LOG_ERROR(#{
-                what => pause_owner_crashed,
-                state => State,
-                paused_by_pid => Pid,
-                reason => Reason
-            }),
+            %% Ignore logging if the process exited normally
+            case Reason of
+                normal ->
+                    ok;
+                _ ->
+                    ?LOG_ERROR(#{
+                        what => pause_owner_crashed,
+                        state => State,
+                        paused_by_pid => Pid,
+                        reason => Reason
+                    })
+            end,
             handle_unpause2(Mon, Mons, State);
         false ->
             handle_down2(Pid, Reason, State)

--- a/test/cets_test_log.erl
+++ b/test/cets_test_log.erl
@@ -1,0 +1,63 @@
+%% Logger helper module
+-module(cets_test_log).
+-export([
+    receive_all_logs_with_log_ref/2,
+    receive_all_logs_from_pid/2
+]).
+
+-include_lib("kernel/include/logger.hrl").
+
+receive_all_logs_with_log_ref(LogHandlerId, LogRef) ->
+    ensure_logger_is_working(LogHandlerId, LogRef),
+    %% Do a new logging call to check that it is the only log message
+    ?LOG_ERROR(#{what => ensure_nothing_logged_after, log_ref => LogRef}),
+    receive_all_logs_with_log_ref_loop(LogHandlerId, LogRef).
+
+receive_all_logs_with_log_ref_loop(LogHandlerId, LogRef) ->
+    %% We only match messages with the matching log_ref here
+    %% to ignore messages from the other parallel tests
+    receive
+        {log, LogHandlerId, Log = #{msg := {report, Report = #{log_ref := LogRef}}}} ->
+            case Report of
+                #{what := ensure_nothing_logged_after} ->
+                    [];
+                _ ->
+                    [Log | receive_all_logs_with_log_ref_loop(LogHandlerId, LogRef)]
+            end
+    after 5000 ->
+        ct:fail({timeout, receive_all_logs_with_log_ref})
+    end.
+
+%% Return logged messages so far. Filters by pid.
+receive_all_logs_from_pid(LogHandlerId, Pid) ->
+    LogRef = make_ref(),
+    ensure_logger_is_working(LogHandlerId, LogRef),
+    %% Do a new logging call to check that it is the only log message
+    ?LOG_ERROR(#{what => ensure_nothing_logged_after, log_ref => LogRef}),
+    receive_all_logs_from_pid_loop(LogHandlerId, Pid, LogRef).
+
+receive_all_logs_from_pid_loop(LogHandlerId, Pid, LogRef) ->
+    %% We only match messages with the matching log_ref here
+    %% to ignore messages from the other parallel tests
+    receive
+        {log, LogHandlerId, #{msg := {report, #{log_ref := LogRef}}}} ->
+            %% Finish waiting
+            [];
+        {log, LogHandlerId, Log = #{meta := #{pid := Pid}}} ->
+            [Log | receive_all_logs_from_pid_loop(LogHandlerId, Pid, LogRef)];
+        {log, LogHandlerId, _Log} ->
+            receive_all_logs_from_pid_loop(LogHandlerId, Pid, LogRef)
+    after 5000 ->
+        ct:fail({timeout, receive_all_logs_from_pid})
+    end.
+
+ensure_logger_is_working(LogHandlerId, LogRef) ->
+    ?LOG_ERROR(#{what => ensure_nothing_logged_before, log_ref => LogRef}),
+    receive
+        {log, LogHandlerId, #{
+            msg := {report, #{log_ref := LogRef, what := ensure_nothing_logged_before}}
+        }} ->
+            ok
+    after 5000 ->
+        ct:fail({timeout, logger_is_broken})
+    end.


### PR DESCRIPTION
MIM-2145

`pause_owner_crashed` log message informs the admin, that something is wrong with the code that called `cets:pause/1` function.

Pause is unpaused when:
- the pause caller exits.
- `cets:unpause/2` is called.

But recent changes for `cets_join` now use exit with reason=normal.

Changes:
- Ignore pause_owner_crashed.
- New helper function for tests `receive_all_logs_from_pid`.
- Move logger helper functions into a separate test helper module.

This just reduce number of logged messages, no changes to the join logic.