### PR TITLE
Do not run check in cets_discovery on nodedown

### DIFF
--- a/src/cets.erl
+++ b/src/cets.erl
@@ -656,9 +656,12 @@ handle_down2(RemotePid, Reason, State = #{other_servers := Servers, ack_pid := A
     case lists:member(RemotePid, Servers) of
         true ->
             cets_ack:send_remote_down(AckPid, RemotePid),
-            call_user_handle_down(RemotePid, State),
             Servers2 = lists:delete(RemotePid, Servers),
-            update_node_down_history(RemotePid, Reason, set_other_servers(Servers2, State));
+            State3 = update_node_down_history(
+                RemotePid, Reason, set_other_servers(Servers2, State)
+            ),
+            call_user_handle_down(RemotePid, State3),
+            State3;
         false ->
             %% This should not happen
             ?LOG_ERROR(#{

--- a/src/cets.erl
+++ b/src/cets.erl
@@ -204,7 +204,7 @@
     (
         #{
             remote_pid := server_pid(),
-            remote_pid := node(),
+            remote_node := node(),
             table := table_name(),
             is_leader := boolean()
         }
@@ -913,8 +913,8 @@ call_user_handle_down(RemotePid, #{tab := Tab, opts := Opts, is_leader := IsLead
         #{handle_down := F} ->
             FF = fun() ->
                 F(#{
-                    remote_node => node(RemotePid),
                     remote_pid => RemotePid,
+                    remote_node => node(RemotePid),
                     table => Tab,
                     is_leader => IsLeader
                 })

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -658,10 +658,8 @@ time_since_startup_in_milliseconds(#{start_time := StartTime}) ->
     time_since(StartTime).
 
 -spec time_since(integer()) -> integer().
-time_since(StartTime) ->
-    %% Dialyzer thinks integer() - integer() could be float.
-    %% Do round to avoid the warning.
-    round(get_time() - StartTime).
+time_since(StartTime) when is_integer(StartTime) ->
+    get_time() - StartTime.
 
 -spec get_time() -> milliseconds().
 get_time() ->

--- a/src/cets_discovery.erl
+++ b/src/cets_discovery.erl
@@ -582,7 +582,7 @@ has_join_result_for(Node, Table, #{results := Results}) ->
 
 -spec handle_system_info(state()) -> system_info().
 handle_system_info(State) ->
-    State#{verify_ready => verify_ready(State)}.
+    State#{verify_ready => verify_ready(State), retry_type => choose_retry_type(State)}.
 
 -spec handle_nodedown(node(), state()) -> state().
 handle_nodedown(Node, State = #{unavailable_nodes := UnNodes}) ->

--- a/src/cets_join.erl
+++ b/src/cets_join.erl
@@ -100,7 +100,7 @@ join_loop(LockKey, Info, LocalPid, RemotePid, Start, JoinOpts) ->
     LockRequest = {LockKey, self()},
     %% Just lock all nodes, no magic here :)
     Nodes = [node() | nodes()],
-    Retries = 1,
+    Retries = 0,
     %% global could abort the transaction when one of the nodes goes down.
     %% It could usually abort it during startup or update.
     case global:trans(LockRequest, F, Nodes, Retries) of

--- a/test/cets_SUITE.erl
+++ b/test/cets_SUITE.erl
@@ -2654,7 +2654,10 @@ disco_node_down_timestamp_is_remembered(Config) ->
 disco_logs_nodeup_after_downtime(Config) ->
     logger_debug_h:start(#{id => ?FUNCTION_NAME}),
     #{disco := Disco, node2 := Node2} = setup_two_nodes_and_discovery(Config, [wait, netsplit]),
-    %% At this point cets_disco should reconnect nodes back automatically.
+    %% At this point cets_disco should reconnect nodes back automatically
+    %% after retry_type_to_timeout(after_nodedown) time.
+    %% We want to speed this up for tests though.
+    Disco ! check,
     %% Receive a nodeup after the disconnect.
     %% This nodeup should contain the downtime_millisecond_duration field
     %% (initial nodeup should not contain this field).


### PR DESCRIPTION
Patches for disco.

- Do not call check on nodedown. This prevents immediate reconnect (which could confuse code inside global, trying to execute logic for prevent_overlapping_partitions).

- If nodedown is received, wait 30 second before the next check. This allows the restarting node to initiate the connection on its own, without the whole cluster trying to connect to it.

- Improve logging for when wait_for_ready fails.

- Provide extra args into handle_down_fun: is_leader and remote_node
