### PR TITLE
Dist blocker

### DIFF
--- a/src/cets_dist_blocker.erl
+++ b/src/cets_dist_blocker.erl
@@ -67,7 +67,7 @@ handle_call({cleaning_done, CleanerPid, Node}, _From, State) ->
     {reply, ok, maybe_unblock(State, handle_cleaning_done(CleanerPid, Node, State))};
 handle_call(Request, _From, State) ->
     ?LOG_ERROR(#{what => unexpected_call, msg => Request}),
-    {reply, ok, State}.
+    {reply, {error, unexpected_call}, State}.
 
 handle_cast(Msg, State) ->
     ?LOG_ERROR(#{what => unexpected_cast, msg => Msg}),

--- a/src/cets_dist_blocker.erl
+++ b/src/cets_dist_blocker.erl
@@ -3,7 +3,7 @@
 %% This module prevents a node from reconnecting, until cleaning activity is
 %% finished. It prevents race conditions.
 %%
-%% This module assume all nodes share the same cookie.
+%% This module assumes all nodes share the same cookie.
 -module(cets_dist_blocker).
 -behaviour(gen_server).
 -include_lib("kernel/include/logger.hrl").
@@ -50,7 +50,8 @@ add_cleaner(CleanerPid) ->
 
 %% @doc Confirm that cleaning is done.
 %%
-%% This function is called by a cleaner after it receives nodedown.
+%% This function should be called by a cleaner when it receives
+%% nodedown and finishes cleaning.
 -spec cleaning_done(pid(), node()) -> ok.
 cleaning_done(CleanerPid, Node) ->
     gen_server:call(?MODULE, {cleaning_done, CleanerPid, Node}).

--- a/src/cets_dist_blocker.erl
+++ b/src/cets_dist_blocker.erl
@@ -39,15 +39,18 @@
     waiting := waiting()
 }.
 
+%% @doc Spawn `dist_blocker'
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% Register Pid as a cleaner.
+%% @doc Register CleanerPid as a cleaner.
 -spec add_cleaner(pid()) -> ok.
 add_cleaner(CleanerPid) ->
     gen_server:call(?MODULE, {add_cleaner, CleanerPid}).
 
-%% Cleaner calls must call this function.
+%% @doc Confirm that cleaning is done.
+%%
+%% This function is called by a cleaner after it receives nodedown.
 -spec cleaning_done(pid(), node()) -> ok.
 cleaning_done(CleanerPid, Node) ->
     gen_server:call(?MODULE, {cleaning_done, CleanerPid, Node}).

--- a/src/cets_dist_blocker.erl
+++ b/src/cets_dist_blocker.erl
@@ -1,0 +1,153 @@
+%% @doc Disallow distributed erlang connections until cleaning is done.
+%%
+%% This module prevents a node from reconnecting, until cleaning activity is
+%% finished. It prevents race conditions.
+%%
+%% This module assume all nodes share the same cookie.
+-module(cets_dist_blocker).
+-behaviour(gen_server).
+-include_lib("kernel/include/logger.hrl").
+
+%% API
+-export([
+    start_link/0,
+    add_cleaner/1,
+    cleaning_done/2
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-ignore_xref([
+    start_link/0,
+    add_cleaner/1,
+    cleaning_done/2
+]).
+
+-type cleaner_pid() :: pid().
+-type waiting() :: [{node(), cleaner_pid()}].
+
+-type state() :: #{
+    cleaners := [cleaner_pid()],
+    waiting := waiting()
+}.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% Register Pid as a cleaner.
+-spec add_cleaner(pid()) -> ok.
+add_cleaner(CleanerPid) ->
+    gen_server:call(?MODULE, {add_cleaner, CleanerPid}).
+
+%% Cleaner calls must call this function.
+-spec cleaning_done(pid(), node()) -> ok.
+cleaning_done(CleanerPid, Node) ->
+    gen_server:call(?MODULE, {cleaning_done, CleanerPid, Node}).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+init([]) ->
+    ok = net_kernel:monitor_nodes(true),
+    State = #{cleaners => [], waiting => []},
+    State2 = lists:foldl(fun handle_nodeup/2, State, nodes()),
+    {ok, State2}.
+
+handle_call({add_cleaner, CleanerPid}, _From, State) ->
+    {reply, ok, handle_add_cleaner(CleanerPid, State)};
+handle_call({cleaning_done, CleanerPid, Node}, _From, State) ->
+    {reply, ok, maybe_unblock(State, handle_cleaning_done(CleanerPid, Node, State))};
+handle_call(Request, _From, State) ->
+    ?LOG_ERROR(#{what => unexpected_call, msg => Request}),
+    {reply, ok, State}.
+
+handle_cast(Msg, State) ->
+    ?LOG_ERROR(#{what => unexpected_cast, msg => Msg}),
+    {noreply, State}.
+
+handle_info({nodeup, Node}, State) ->
+    {noreply, handle_nodeup(Node, State)};
+handle_info({nodedown, Node}, State) ->
+    {noreply, handle_nodedown(Node, State)};
+handle_info({'DOWN', _Ref, process, Pid, _Info}, State) ->
+    {noreply, maybe_unblock(State, handle_cleaner_down(Pid, State))};
+handle_info(Info, State) ->
+    ?LOG_ERROR(#{what => unexpected_info, msg => Info}),
+    {noreply, State}.
+
+terminate(_Reason, State) ->
+    %% Restore cookies
+    _ = maybe_unblock(State, State#{waiting := []}),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% internal functions
+%%--------------------------------------------------------------------
+
+-spec handle_nodeup(node(), state()) -> state().
+handle_nodeup(Node, State) ->
+    %% We change the cookie as soon as the node is connected.
+    %% Alternative is to do it on nodedown, but because nodedown-s are async,
+    %% we would have a high chance of race conditions (so, node could reconnect
+    %% before we set cookie).
+    erlang:set_cookie(Node, blocking_cookie()),
+    State.
+
+%% Make cookie, that would prevent node from connecting
+-spec blocking_cookie() -> atom().
+blocking_cookie() ->
+    list_to_atom(atom_to_list(erlang:get_cookie()) ++ "_blocked_by_" ++ atom_to_list(node())).
+
+%% Allow the node to connect to us again
+-spec unblock_node(node(), state()) -> state().
+unblock_node(Node, State) ->
+    erlang:set_cookie(Node, erlang:get_cookie()),
+    State.
+
+-spec handle_nodedown(node(), state()) -> state().
+handle_nodedown(Node, State = #{cleaners := []}) ->
+    %% Skip waiting when no cleaners
+    unblock_node(Node, State);
+handle_nodedown(Node, State = #{cleaners := Cleaners, waiting := Waiting}) ->
+    New = [{Node, CleanerPid} || CleanerPid <- Cleaners],
+    State#{waiting := lists:usort(New ++ Waiting)}.
+
+-spec handle_add_cleaner(cleaner_pid(), state()) -> state().
+handle_add_cleaner(CleanerPid, State = #{cleaners := Cleaners}) ->
+    erlang:monitor(process, CleanerPid),
+    State#{cleaners := lists:usort([CleanerPid | Cleaners])}.
+
+-spec handle_cleaning_done(cleaner_pid(), node(), state()) -> state().
+handle_cleaning_done(CleanerPid, Node, State = #{waiting := Waiting}) ->
+    State#{waiting := lists:delete({Node, CleanerPid}, Waiting)}.
+
+-spec handle_cleaner_down(cleaner_pid(), state()) -> state().
+handle_cleaner_down(CleanerPid, State = #{cleaners := Cleaners, waiting := Waiting}) ->
+    State#{
+        cleaners := lists:delete(CleanerPid, Cleaners),
+        waiting := [X || {_Node, CleanerPid2} = X <- Waiting, CleanerPid =/= CleanerPid2]
+    }.
+
+%% Unblock nodes when the last cleaner confirms the cleaning is done.
+%% Call this function each time you remove entries from the waiting list.
+-spec maybe_unblock(state(), state()) -> state().
+maybe_unblock(_OldState = #{waiting := OldWaiting}, NewState = #{waiting := NewWaiting}) ->
+    OldNodes = cast_waiting_to_nodes(OldWaiting),
+    NewNodes = cast_waiting_to_nodes(NewWaiting),
+    CleanedNodes = OldNodes -- NewNodes,
+    lists:foldl(fun unblock_node/2, NewState, CleanedNodes).
+
+-spec cast_waiting_to_nodes(waiting()) -> [node()].
+cast_waiting_to_nodes(Waiting) ->
+    lists:usort([Node || {Node, _CleanerPid} <- Waiting]).

--- a/test/cets_dist_blocker_SUITE.erl
+++ b/test/cets_dist_blocker_SUITE.erl
@@ -14,6 +14,7 @@ all_cases() ->
         dist_blocker_waits_for_cleaning,
         dist_blocker_unblocks_if_cleaner_goes_down,
         dist_blocker_unblocks_if_cleaner_goes_down_and_second_cleaner_says_done,
+        dist_blocker_unblocks_if_cleaner_says_done_and_second_cleaner_goes_down,
         dist_blocker_skip_blocking_if_no_cleaners,
         unknown_down_message_is_ignored,
         unknown_message_is_ignored,
@@ -87,6 +88,23 @@ dist_blocker_unblocks_if_cleaner_goes_down_and_second_cleaner_says_done(Config) 
     pang = net_adm:ping(Node2),
     erlang:exit(Cleaner, killed),
     cets_dist_blocker:cleaning_done(self(), Node2),
+    %% Connection is unblocked
+    pong = net_adm:ping(Node2),
+    gen_server:stop(Blocker).
+
+dist_blocker_unblocks_if_cleaner_says_done_and_second_cleaner_goes_down(Config) ->
+    #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
+    {ok, Blocker} = cets_dist_blocker:start_link(),
+    %% Two cleaners
+    cets_dist_blocker:add_cleaner(self()),
+    Cleaner = spawn_cleaner(),
+    pong = net_adm:ping(Node2),
+    true = erlang:disconnect_node(Node2),
+    %% Connection is blocked
+    pang = net_adm:ping(Node2),
+    %% Different order comparing to dist_blocker_unblocks_if_cleaner_goes_down_and_second_cleaner_says_done
+    cets_dist_blocker:cleaning_done(self(), Node2),
+    erlang:exit(Cleaner, killed),
     %% Connection is unblocked
     pong = net_adm:ping(Node2),
     gen_server:stop(Blocker).

--- a/test/cets_dist_blocker_SUITE.erl
+++ b/test/cets_dist_blocker_SUITE.erl
@@ -13,9 +13,12 @@ all_cases() ->
     [
         dist_blocker_waits_for_cleaning,
         dist_blocker_unblocks_if_cleaner_goes_down,
+        dist_blocker_unblocks_if_cleaner_goes_down_and_second_cleaner_says_done,
+        dist_blocker_skip_blocking_if_no_cleaners,
         unknown_down_message_is_ignored,
         unknown_message_is_ignored,
         unknown_cast_message_is_ignored,
+        unknown_call_returns_error,
         code_change_returns_ok
     ].
 
@@ -60,24 +63,39 @@ dist_blocker_waits_for_cleaning(Config) ->
     gen_server:stop(Blocker).
 
 dist_blocker_unblocks_if_cleaner_goes_down(Config) ->
-    Me = self(),
     #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
     {ok, Blocker} = cets_dist_blocker:start_link(),
-    Cleaner = proc_lib:spawn(fun() ->
-        cets_dist_blocker:add_cleaner(self()),
-        Me ! added,
-        timer:sleep(infinity)
-    end),
-    receive
-        added -> ok
-    after 5000 -> ct:fail(timeout)
-    end,
+    Cleaner = spawn_cleaner(),
     pong = net_adm:ping(Node2),
     true = erlang:disconnect_node(Node2),
     %% Connection is blocked
     pang = net_adm:ping(Node2),
     erlang:exit(Cleaner, killed),
     %% Connection is unblocked
+    pong = net_adm:ping(Node2),
+    gen_server:stop(Blocker).
+
+dist_blocker_unblocks_if_cleaner_goes_down_and_second_cleaner_says_done(Config) ->
+    #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
+    {ok, Blocker} = cets_dist_blocker:start_link(),
+    %% Two cleaners
+    cets_dist_blocker:add_cleaner(self()),
+    Cleaner = spawn_cleaner(),
+    pong = net_adm:ping(Node2),
+    true = erlang:disconnect_node(Node2),
+    %% Connection is blocked
+    pang = net_adm:ping(Node2),
+    erlang:exit(Cleaner, killed),
+    cets_dist_blocker:cleaning_done(self(), Node2),
+    %% Connection is unblocked
+    pong = net_adm:ping(Node2),
+    gen_server:stop(Blocker).
+
+dist_blocker_skip_blocking_if_no_cleaners(Config) ->
+    #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
+    {ok, Blocker} = cets_dist_blocker:start_link(),
+    pong = net_adm:ping(Node2),
+    true = erlang:disconnect_node(Node2),
     pong = net_adm:ping(Node2),
     gen_server:stop(Blocker).
 
@@ -97,6 +115,11 @@ unknown_cast_message_is_ignored(_Config) ->
     gen_server:cast(Pid, oops),
     still_works(Pid).
 
+unknown_call_returns_error(_Config) ->
+    {ok, Pid} = cets_dist_blocker:start_link(),
+    {error, unexpected_call} = gen_server:call(Pid, oops),
+    still_works(Pid).
+
 code_change_returns_ok(_Config) ->
     {ok, Pid} = cets_dist_blocker:start_link(),
     sys:suspend(Pid),
@@ -106,3 +129,16 @@ code_change_returns_ok(_Config) ->
 
 still_works(Pid) ->
     #{} = sys:get_state(Pid).
+
+spawn_cleaner() ->
+    Me = self(),
+    Cleaner = proc_lib:spawn(fun() ->
+        cets_dist_blocker:add_cleaner(self()),
+        Me ! added,
+        timer:sleep(infinity)
+    end),
+    receive
+        added -> ok
+    after 5000 -> ct:fail(timeout)
+    end,
+    Cleaner.

--- a/test/cets_dist_blocker_SUITE.erl
+++ b/test/cets_dist_blocker_SUITE.erl
@@ -1,0 +1,78 @@
+-module(cets_dist_blocker_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("kernel/include/logger.hrl").
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [{group, all}].
+
+groups() ->
+    [{all, [sequence, {repeat_until_any_fail, 2}], all_cases()}].
+
+all_cases() ->
+    [
+        dist_blocker_waits_for_cleaning,
+        dist_blocker_unblocks_if_cleaner_goes_down
+    ].
+
+init_per_suite(Config) ->
+    Names = [peer_ct2],
+    {Nodes, Peers} = lists:unzip([cets_test_peer:start_node(N) || N <- Names]),
+    [
+        {nodes, maps:from_list(lists:zip(Names, Nodes))},
+        {peers, maps:from_list(lists:zip(Names, Peers))}
+        | Config
+    ].
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(Name, Config) ->
+    init_per_testcase_generic(Name, Config).
+
+init_per_testcase_generic(Name, Config) ->
+    [{testcase, Name} | Config].
+
+end_per_testcase(_, _Config) ->
+    ok.
+
+dist_blocker_waits_for_cleaning(Config) ->
+    #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
+    {ok, Blocker} = cets_dist_blocker:start_link(),
+    cets_dist_blocker:add_cleaner(self()),
+    pong = net_adm:ping(Node2),
+    true = erlang:disconnect_node(Node2),
+    %% Connection is blocked
+    pang = net_adm:ping(Node2),
+    cets_dist_blocker:cleaning_done(self(), Node2),
+    %% Connection is unblocked
+    pong = net_adm:ping(Node2),
+    gen_server:stop(Blocker).
+
+dist_blocker_unblocks_if_cleaner_goes_down(Config) ->
+    Me = self(),
+    #{peer_ct2 := Node2} = proplists:get_value(nodes, Config),
+    {ok, Blocker} = cets_dist_blocker:start_link(),
+    Cleaner = proc_lib:spawn(fun() ->
+        cets_dist_blocker:add_cleaner(self()),
+        Me ! added,
+        timer:sleep(infinity)
+    end),
+    receive
+        added -> ok
+    after 5000 -> ct:fail(timeout)
+    end,
+    pong = net_adm:ping(Node2),
+    true = erlang:disconnect_node(Node2),
+    %% Connection is blocked
+    pang = net_adm:ping(Node2),
+    erlang:exit(Cleaner, killed),
+    %% Connection is unblocked
+    pong = net_adm:ping(Node2),
+    gen_server:stop(Blocker).

--- a/test/cets_test_peer.erl
+++ b/test/cets_test_peer.erl
@@ -1,0 +1,42 @@
+-module(cets_test_peer).
+-export([
+    start_node/1,
+    node_to_peer/1
+]).
+-include_lib("common_test/include/ct.hrl").
+
+start_node(Sname) ->
+    {ok, Peer, Node} = ?CT_PEER(#{
+        name => Sname, connection => standard_io, args => extra_args(Sname)
+    }),
+    %% Register so we can find Peer process later in code
+    register(node_to_peer_name(Node), Peer),
+    %% Keep nodes running after init_per_suite is finished
+    unlink(Peer),
+    %% Do RPC using alternative connection method
+    ok = peer:call(Peer, code, add_paths, [code:get_path()]),
+    {Node, Peer}.
+
+%% Returns Peer or Node name which could be used to do RPC-s reliably
+%% (regardless if Erlang Distribution works or not)
+node_to_peer(Node) when Node =:= node() ->
+    %% There is no peer for the local CT node
+    Node;
+node_to_peer(Node) when is_atom(Node) ->
+    case whereis(node_to_peer_name(Node)) of
+        Pid when is_pid(Pid) ->
+            Pid;
+        undefined ->
+            ct:fail({node_to_peer_failed, Node})
+    end.
+
+node_to_peer_name(Node) ->
+    list_to_atom(atom_to_list(Node) ++ "_peer").
+
+%% Set epmd_port for better coverage
+extra_args(ct2) ->
+    ["-epmd_port", "4369"];
+extra_args(X) when X == ct5; X == ct6; X == ct7 ->
+    ["-kernel", "prevent_overlapping_partitions", "false"];
+extra_args(_) ->
+    "".


### PR DESCRIPTION
In this PR we introduce cets_dist_blocker, which will set cookies that would prevent nodes from reconnecting before cleaning is done.

We use [set_cookie/2](https://www.erlang.org/docs/25/man/erlang#set_cookie-2), which allows to set a particular cookie for a specific remote node (and specific local node). If we set cookie to some random value, the node would not be able to connect to us (also we would not able to connect). But the existing connection will remain. Also, it only affects that specific node, other nodes would use cookie provided by `get_cookie/0` function.

The idea is:
- on nodeup we set cookie to something different for that particular node, so the next time it tries to reconnect, it will not able to.
- on nodedown we would wait for all the cleaner processes to ack that they've finished handling `nodedown` message (sent using `monitor_nodes` call).
- we only do it on a local node (i.e. no coordination between dist_blockers in cluster). Each MongooseIM node has a dist_blocker process though, just no messaging between them. Reason: simplicity. Also, that approach is enough to fix most of the issues.

This PR addresses "sessionCount is incorrect during upgrades".
The final goal is to make global's prevent_overlapped_partitions reliable.

Proposed changes include:
* cets_dist_blocker server, which provides API to block node from reconnecting, unless we do cleaning first.
* Test helper to start peer nodes.

PR to MongooseIM: https://github.com/esl/MongooseIM/pull/4234
PR to MongooseHelm: https://github.com/esl/MongooseHelm/pull/38
